### PR TITLE
Fetching Node metrics directly, not assuming container metrics and pod container lists will always match up

### DIFF
--- a/pkg/capacity/list_test.go
+++ b/pkg/capacity/list_test.go
@@ -261,6 +261,18 @@ func getTestClusterMetric() clusterMetric {
 					},
 				},
 			},
+		}, &v1beta1.NodeMetricsList{
+			Items: []v1beta1.NodeMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-node-1",
+					},
+					Usage: corev1.ResourceList{
+						"cpu":    resource.MustParse("63m"),
+						"memory": resource.MustParse("439Mi"),
+					},
+				},
+			},
 		},
 	)
 }

--- a/pkg/capacity/resources_test.go
+++ b/pkg/capacity/resources_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestBuildClusterMetricEmpty(t *testing.T) {
 	cm := buildClusterMetric(
-		&corev1.PodList{}, &v1beta1.PodMetricsList{}, &corev1.NodeList{},
+		&corev1.PodList{}, &v1beta1.PodMetricsList{}, &corev1.NodeList{}, &v1beta1.NodeMetricsList{},
 	)
 
 	expected := clusterMetric{
@@ -129,6 +129,18 @@ func TestBuildClusterMetricFull(t *testing.T) {
 					},
 				},
 			},
+		}, &v1beta1.NodeMetricsList{
+			Items: []v1beta1.NodeMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-node-1",
+					},
+					Usage: corev1.ResourceList{
+						"cpu":    resource.MustParse("43m"),
+						"memory": resource.MustParse("349Mi"),
+					},
+				},
+			},
 		},
 	)
 
@@ -136,14 +148,14 @@ func TestBuildClusterMetricFull(t *testing.T) {
 		allocatable: resource.MustParse("1000m"),
 		request:     resource.MustParse("350m"),
 		limit:       resource.MustParse("400m"),
-		utilization: resource.MustParse("23m"),
+		utilization: resource.MustParse("43m"),
 	}
 
 	memoryExpected := &resourceMetric{
 		allocatable: resource.MustParse("4000Mi"),
 		request:     resource.MustParse("400Mi"),
 		limit:       resource.MustParse("700Mi"),
-		utilization: resource.MustParse("299Mi"),
+		utilization: resource.MustParse("349Mi"),
 	}
 
 	assert.NotNil(t, cm.cpu)

--- a/pkg/capacity/table.go
+++ b/pkg/capacity/table.go
@@ -64,10 +64,13 @@ func (tp *tablePrinter) Print() {
 
 	if len(sortedNodeMetrics) > 1 {
 		tp.printClusterLine()
-		tp.printLine(&tableLine{})
 	}
 
 	for _, nm := range sortedNodeMetrics {
+		if tp.showPods || tp.showContainers {
+			tp.printLine(&tableLine{})
+		}
+
 		tp.printNodeLine(nm.name, nm)
 
 		if tp.showPods || tp.showContainers {

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -28,6 +28,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of kube-capacity",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("kube-capacity version 0.3.1")
+		fmt.Println("kube-capacity version 0.3.2")
 	},
 }


### PR DESCRIPTION
This should fix #15 and #16.

In #15, a segmentation fault occurred. This seems to have been caused by a container being returned from the metrics API that was not returned by the pods API. I've added a nil check to cover that. 

In #16, kube-capacity was showing different node totals than kubectl top. I believe that is because I had been summing pod metrics as opposed to fetching node metrics. This misses any util that might be happening outside of the scope of Kubernetes on each node. I've switched around the logic to fetch node metrics and base those numbers off of the numbers returned by the metrics API for nodes themselves.