### PR TITLE
changes to do automated releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,14 +24,42 @@ jobs:
       - checkout
       - run: curl -sL https://git.io/goreleaser | bash
 
+
+  update-krew-index:
+    working_directory: /go/src/github.com/robscott/kube-capacity
+
+    docker:
+      - image: circleci/golang:1.13
+        environment:
+          KREW_RELEASE_BOT_WEBHOOK_URL: https://krew-release-bot-dryrun.rajatjindal.com/github-action-webhook
+          KREW_RELEASE_BOT_VERSION: v0.0.34-4
+    steps:
+      - checkout
+      - run: |
+          echo "using krew-release-bot version ${KREW_RELEASE_BOT_VERSION}"
+          curl -LO https://github.com/rajatjindal/krew-release-bot/releases/download/${KREW_RELEASE_BOT_VERSION}/krew-release-bot_${KREW_RELEASE_BOT_VERSION}_linux_amd64.tar.gz
+          tar -xvf krew-release-bot_${KREW_RELEASE_BOT_VERSION}_linux_amd64.tar.gz
+      - run: ./krew-release-bot action
+
+
 workflows:
   version: 2
   main:
     jobs:
       - test
+
       - release:
           filters:
             branches:
               ignore: /.*/
             tags:
               only: /[0-9]+(\.[0-9]+)*(-.*)*/
+
+      - update-krew-index:
+          requires:
+            - release
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /[0-9]+(\.[0-9]+)*(-.*)*/ 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,9 +46,13 @@ workflows:
   version: 2
   main:
     jobs:
-      - test
-
+      - test:
+          filters:
+            tags:
+              only: /.*/
       - release:
+          requires:
+            - test
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,24 @@ jobs:
       - run: go list ./... | grep -v vendor | xargs go vet
       - run: go test ./pkg/... -v -coverprofile cover.out
 
+  release:
+    working_directory: /go/src/github.com/robscott/kube-capacity
+    
+    docker:
+      - image: circleci/golang:1.13
+
+    steps:
+      - checkout
+      - run: curl -sL https://git.io/goreleaser | bash
+
 workflows:
   version: 2
-  test:
+  main:
     jobs:
       - test
+      - release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /[0-9]+(\.[0-9]+)*(-.*)*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     working_directory: /go/src/github.com/robscott/kube-capacity
 
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,7 @@ jobs:
     docker:
       - image: circleci/golang:1.13
         environment:
-          KREW_RELEASE_BOT_WEBHOOK_URL: https://krew-release-bot-dryrun.rajatjindal.com/github-action-webhook
-          KREW_RELEASE_BOT_VERSION: v0.0.34-4
+          KREW_RELEASE_BOT_VERSION: v0.0.35
     steps:
       - checkout
       - run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,13 +1,13 @@
 builds:
 - env:
   - CGO_ENABLED=0
-archive:
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -18,11 +18,11 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
-brew:
-  github:
-    owner: robscott
-    name: homebrew-tap
-  folder: Formula
-  description: kube-capacity provides an overview of the resource requests, limits, and utilization in a Kubernetes cluster
-  test: |
-    system "#{bin}/kube-capacity version"
+brews:
+  - github:
+      owner: robscott
+      name: homebrew-tap
+    folder: Formula
+    description: kube-capacity provides an overview of the resource requests, limits, and utilization in a Kubernetes cluster
+    test: |
+      system "#{bin}/kube-capacity version"  

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,29 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: resource-capacity
+spec:
+  version: v{{ .TagName }}
+  homepage: https://github.com/robscott/kube-capacity
+  shortDescription: Provides an overview of resource requests, limits, and utilization
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    bin: kube-capacity
+    files:
+    - from: "*"
+      to: "."
+    {{addURIAndSha "https://github.com/robscott/kube-capacity/releases/download/{{ .TagName }}/kube-capacity_{{ .TagName }}_Darwin_x86_64.tar.gz" .TagName }}    
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    bin: kube-capacity
+    files:
+    - from: "*"
+      to: "."
+    {{addURIAndSha "https://github.com/robscott/kube-capacity/releases/download/{{ .TagName }}/kube-capacity_{{ .TagName }}_Linux_x86_64.tar.gz" .TagName }}
+  description: |
+    A simple CLI that provides an overview of the resource requests, limits, and utilization in a Kubernetes cluster.


### PR DESCRIPTION
Hi Rob,

This PR is still work in progress, but enough to get the review started. 

It has following changes:

- updated the version of go to 1.13
- added go-releaser as part of circle-ci config
- fixed the deprecated/removed go-releaser config files
- added krew-release-bot to circle-ci config


TODO:

- release new version of krew-release-bot with circle-ci support (pending review)
- update this PR with new version of krew-release-bot

I am going to close the other 2 PR in favor of this one.

Thanks
Rajat Jindal
