### PR TITLE
adding ability to display usage in terms of total not percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ example-node-1    220m (22%)      10m (1%)      10m (1%)    192Mi (6%)         3
 example-node-2    340m (34%)      120m (12%)    30m (3%)    380Mi (13%)        410Mi (14%)     260Mi (9%)
 ```
 
+### Displaying Available Resources
+To more clearly see the total available resources on the node it is possible to pass the `--available` option
+to kube-capacity, which will give output in the following format
+
+```
+kube-capacity --available
+
+NODE              CPU REQUESTS    CPU LIMITS    MEMORY REQUESTS    MEMORY LIMITS
+*                 560/2000m       130/2000m     572/5923Mi         770/5923Mi 
+example-node-1    220/1000m       10/1000m      192/3200Mi         360/3200Mi 
+example-node-2    340/1000m       120/1000m     380/2923Mi         410/2923Mi
+```
+
 ### Including Pods and Utilization
 For more detailed output, kube-capacity can include both pods and resource utilization in the output. When `--util` and `--pods` are passed to kube-capacity, it will result in a wide output that looks like this:
 
@@ -120,6 +133,7 @@ kube-capacity --pods --containers --util --output yaml
   -o, --output string             output format for information
                                     (supports: [table json yaml])
                                     (default "table")
+  -a, --available                 includes quantity available instead of percentage used
   -l, --pod-labels string         labels to filter pods with
   -p, --pods                      includes pods in output
       --sort string               attribute to sort results be (supports:
@@ -143,6 +157,7 @@ Although this project was originally developed by [robscott](https://github.com/
 
 - [endzyme](https://github.com/endzyme)
 - [justinbarrick](https://github.com/justinbarrick)
+- [Padarn](https://github.com/Padarn)
 
 ## License
 Apache License 2.0

--- a/pkg/capacity/capacity.go
+++ b/pkg/capacity/capacity.go
@@ -28,7 +28,7 @@ import (
 )
 
 // FetchAndPrint gathers cluster resource data and outputs it
-func FetchAndPrint(showContainers, showPods, showUtil bool, podLabels, nodeLabels, namespaceLabels, kubeContext, output, sortBy string) {
+func FetchAndPrint(showContainers, showPods, showUtil, availableFormat bool, podLabels, nodeLabels, namespaceLabels, kubeContext, output, sortBy string) {
 	clientset, err := kube.NewClientSet(kubeContext)
 	if err != nil {
 		fmt.Printf("Error connecting to Kubernetes: %v\n", err)
@@ -51,7 +51,7 @@ func FetchAndPrint(showContainers, showPods, showUtil bool, podLabels, nodeLabel
 	}
 
 	cm := buildClusterMetric(podList, pmList, nodeList, nmList)
-	printList(&cm, showContainers, showPods, showUtil, output, sortBy)
+	printList(&cm, showContainers, showPods, showUtil, output, sortBy, availableFormat)
 }
 
 func getPodsAndNodes(clientset kubernetes.Interface, podLabels, nodeLabels, namespaceLabels string) (*corev1.PodList, *corev1.NodeList) {

--- a/pkg/capacity/printer.go
+++ b/pkg/capacity/printer.go
@@ -38,7 +38,7 @@ func SupportedOutputs() []string {
 	}
 }
 
-func printList(cm *clusterMetric, showContainers, showPods, showUtil bool, output, sortBy string) {
+func printList(cm *clusterMetric, showContainers, showPods, showUtil bool, output, sortBy string, availableFormat bool) {
 	if output == JSONOutput || output == YAMLOutput {
 		lp := &listPrinter{
 			cm:             cm,
@@ -50,12 +50,13 @@ func printList(cm *clusterMetric, showContainers, showPods, showUtil bool, outpu
 		lp.Print(output)
 	} else if output == TableOutput {
 		tp := &tablePrinter{
-			cm:             cm,
-			showPods:       showPods,
-			showUtil:       showUtil,
-			showContainers: showContainers,
-			sortBy:         sortBy,
-			w:              new(tabwriter.Writer),
+			cm:              cm,
+			showPods:        showPods,
+			showUtil:        showUtil,
+			showContainers:  showContainers,
+			sortBy:          sortBy,
+			w:               new(tabwriter.Writer),
+			availableFormat: availableFormat,
 		}
 		tp.Print()
 	} else {

--- a/pkg/capacity/resources.go
+++ b/pkg/capacity/resources.go
@@ -24,6 +24,10 @@ import (
 	v1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 )
 
+const (
+	byte2MiFactor = 1048576
+)
+
 // SupportedSortAttributes lists the valid sorting options
 var SupportedSortAttributes = [...]string{
 	"cpu.util",
@@ -314,8 +318,8 @@ func resourceString(actual, allocatable resource.Quantity, resourceType string, 
 
 	// Memory default
 	unit := "Mi"
-	actualValue := actual.Value() / 1048576
-	allocatableValue := allocatable.Value() / 1048576
+	actualValue := actual.Value() / byte2MiFactor
+	allocatableValue := allocatable.Value() / byte2MiFactor
 
 	if resourceType == "cpu" {
 		actualValue = actual.MilliValue()
@@ -339,7 +343,7 @@ func (rm resourceMetric) valueFunction() (f func(r resource.Quantity) string) {
 		}
 	case "memory":
 		f = func(r resource.Quantity) string {
-			return fmt.Sprintf("%dMi", r.Value()/1048576)
+			return fmt.Sprintf("%dMi", r.Value()/byte2MiFactor)
 		}
 	}
 	return f

--- a/pkg/capacity/table.go
+++ b/pkg/capacity/table.go
@@ -22,12 +22,13 @@ import (
 )
 
 type tablePrinter struct {
-	cm             *clusterMetric
-	showPods       bool
-	showUtil       bool
-	showContainers bool
-	sortBy         string
-	w              *tabwriter.Writer
+	cm              *clusterMetric
+	showPods        bool
+	showUtil        bool
+	showContainers  bool
+	sortBy          string
+	w               *tabwriter.Writer
+	availableFormat bool
 }
 
 type tableLine struct {
@@ -130,12 +131,12 @@ func (tp *tablePrinter) printClusterLine() {
 		namespace:      "*",
 		pod:            "*",
 		container:      "*",
-		cpuRequests:    tp.cm.cpu.requestString(),
-		cpuLimits:      tp.cm.cpu.limitString(),
-		cpuUtil:        tp.cm.cpu.utilString(),
-		memoryRequests: tp.cm.memory.requestString(),
-		memoryLimits:   tp.cm.memory.limitString(),
-		memoryUtil:     tp.cm.memory.utilString(),
+		cpuRequests:    tp.cm.cpu.requestString(tp.availableFormat),
+		cpuLimits:      tp.cm.cpu.limitString(tp.availableFormat),
+		cpuUtil:        tp.cm.cpu.utilString(tp.availableFormat),
+		memoryRequests: tp.cm.memory.requestString(tp.availableFormat),
+		memoryLimits:   tp.cm.memory.limitString(tp.availableFormat),
+		memoryUtil:     tp.cm.memory.utilString(tp.availableFormat),
 	})
 }
 
@@ -145,12 +146,12 @@ func (tp *tablePrinter) printNodeLine(nodeName string, nm *nodeMetric) {
 		namespace:      "*",
 		pod:            "*",
 		container:      "*",
-		cpuRequests:    nm.cpu.requestString(),
-		cpuLimits:      nm.cpu.limitString(),
-		cpuUtil:        nm.cpu.utilString(),
-		memoryRequests: nm.memory.requestString(),
-		memoryLimits:   nm.memory.limitString(),
-		memoryUtil:     nm.memory.utilString(),
+		cpuRequests:    nm.cpu.requestString(tp.availableFormat),
+		cpuLimits:      nm.cpu.limitString(tp.availableFormat),
+		cpuUtil:        nm.cpu.utilString(tp.availableFormat),
+		memoryRequests: nm.memory.requestString(tp.availableFormat),
+		memoryLimits:   nm.memory.limitString(tp.availableFormat),
+		memoryUtil:     nm.memory.utilString(tp.availableFormat),
 	})
 }
 
@@ -160,12 +161,12 @@ func (tp *tablePrinter) printPodLine(nodeName string, pm *podMetric) {
 		namespace:      pm.namespace,
 		pod:            pm.name,
 		container:      "*",
-		cpuRequests:    pm.cpu.requestString(),
-		cpuLimits:      pm.cpu.limitString(),
-		cpuUtil:        pm.cpu.utilString(),
-		memoryRequests: pm.memory.requestString(),
-		memoryLimits:   pm.memory.limitString(),
-		memoryUtil:     pm.memory.utilString(),
+		cpuRequests:    pm.cpu.requestString(tp.availableFormat),
+		cpuLimits:      pm.cpu.limitString(tp.availableFormat),
+		cpuUtil:        pm.cpu.utilString(tp.availableFormat),
+		memoryRequests: pm.memory.requestString(tp.availableFormat),
+		memoryLimits:   pm.memory.limitString(tp.availableFormat),
+		memoryUtil:     pm.memory.utilString(tp.availableFormat),
 	})
 }
 
@@ -175,11 +176,11 @@ func (tp *tablePrinter) printContainerLine(nodeName string, pm *podMetric, cm *c
 		namespace:      pm.namespace,
 		pod:            pm.name,
 		container:      cm.name,
-		cpuRequests:    cm.cpu.requestString(),
-		cpuLimits:      cm.cpu.limitString(),
-		cpuUtil:        cm.cpu.utilString(),
-		memoryRequests: cm.memory.requestString(),
-		memoryLimits:   cm.memory.limitString(),
-		memoryUtil:     cm.memory.utilString(),
+		cpuRequests:    cm.cpu.requestString(tp.availableFormat),
+		cpuLimits:      cm.cpu.limitString(tp.availableFormat),
+		cpuUtil:        cm.cpu.utilString(tp.availableFormat),
+		memoryRequests: cm.memory.requestString(tp.availableFormat),
+		memoryLimits:   cm.memory.limitString(tp.availableFormat),
+		memoryUtil:     cm.memory.utilString(tp.availableFormat),
 	})
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -59,7 +59,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&showUtil,
 		"util", "u", false, "includes resource utilization in output")
 	rootCmd.PersistentFlags().BoolVarP(&availableFormat,
-		"available", "a", false, "formats the output in terms of available instead of percentage")
+		"available", "a", false, "includes quantity available instead of percentage used")
 	rootCmd.PersistentFlags().StringVarP(&podLabels,
 		"pod-labels", "l", "", "labels to filter pods with")
 	rootCmd.PersistentFlags().StringVarP(&nodeLabels,

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -31,6 +31,7 @@ var namespaceLabels string
 var kubeContext string
 var outputFormat string
 var sortBy string
+var availableFormat bool
 
 var rootCmd = &cobra.Command{
 	Use:   "kube-capacity",
@@ -46,7 +47,7 @@ var rootCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		capacity.FetchAndPrint(showContainers, showPods, showUtil, podLabels, nodeLabels, namespaceLabels, kubeContext, outputFormat, sortBy)
+		capacity.FetchAndPrint(showContainers, showPods, showUtil, availableFormat, podLabels, nodeLabels, namespaceLabels, kubeContext, outputFormat, sortBy)
 	},
 }
 
@@ -57,6 +58,8 @@ func init() {
 		"pods", "p", false, "includes pods in output")
 	rootCmd.PersistentFlags().BoolVarP(&showUtil,
 		"util", "u", false, "includes resource utilization in output")
+	rootCmd.PersistentFlags().BoolVarP(&availableFormat,
+		"available", "a", false, "formats the output in terms of available instead of percentage")
 	rootCmd.PersistentFlags().StringVarP(&podLabels,
 		"pod-labels", "l", "", "labels to filter pods with")
 	rootCmd.PersistentFlags().StringVarP(&nodeLabels,


### PR DESCRIPTION
Adding a new flag `--available` which will allow printing in term of nodes total capacity, e.g.

```
NODE                                   CPU REQUESTS   CPU LIMITS     MEMORY REQUESTS   MEMORY LIMITS
node1                                    949/1900m      3750/1900m     1528/4566Mi       4742/4566Mi
node2                                    985/1900m      4750/1900m     1689/4566Mi       4598/4566Mi
node3                                    375/7820m      450/7820m      737/27722Mi       1624/27722Mi

```