### PR TITLE
add --namespace flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ For more advanced usage, kube-capacity also supports filtering by pod, namespace
 
 ```
 kube-capacity --pod-labels app=nginx
+kube-capacity --namespace default
 kube-capacity --namespace-labels team=api
 kube-capacity --node-labels kubernetes.io/role=node
 ```
@@ -128,8 +129,8 @@ kube-capacity --pods --containers --util --output yaml
   -c, --containers                includes containers in output
       --context string            context to use for Kubernetes config
   -h, --help                      help for kube-capacity
-  -n, --namespace-labels string   labels to filter namespaces with
-      --node-labels string        labels to filter nodes with
+  -n, --namespace string          only include pods from this namespace
+      --namespace-labels string   labels to filter namespaces with
   -o, --output string             output format for information
                                     (supports: [table json yaml])
                                     (default "table")
@@ -158,6 +159,7 @@ Although this project was originally developed by [robscott](https://github.com/
 - [endzyme](https://github.com/endzyme)
 - [justinbarrick](https://github.com/justinbarrick)
 - [Padarn](https://github.com/Padarn)
+- [nickatsegment](https://github.com/nickatsegment)
 
 ## License
 Apache License 2.0

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ kube-capacity --pods --containers --util --output yaml
   -h, --help                      help for kube-capacity
   -n, --namespace string          only include pods from this namespace
       --namespace-labels string   labels to filter namespaces with
+      --node-labels string        labels to filter nodes with
   -o, --output string             output format for information
                                     (supports: [table json yaml])
                                     (default "table")

--- a/pkg/capacity/capacity_test.go
+++ b/pkg/capacity/capacity_test.go
@@ -42,7 +42,7 @@ func TestGetPodsAndNodes(t *testing.T) {
 		pod("mynode", "default", "mypod6", map[string]string{"g": "test"}),
 	)
 
-	podList, nodeList := getPodsAndNodes(clientset, "", "", "")
+	podList, nodeList := getPodsAndNodes(clientset, "", "", "", "")
 	assert.Equal(t, []string{"mynode", "mynode2"}, listNodes(nodeList))
 	assert.Equal(t, []string{
 		"another/mypod5",
@@ -54,7 +54,7 @@ func TestGetPodsAndNodes(t *testing.T) {
 		"other/mypod3",
 	}, listPods(podList))
 
-	podList, nodeList = getPodsAndNodes(clientset, "", "hello=world", "")
+	podList, nodeList = getPodsAndNodes(clientset, "", "hello=world", "", "")
 	assert.Equal(t, []string{"mynode", "mynode2"}, listNodes(nodeList))
 	assert.Equal(t, []string{
 		"another/mypod5",
@@ -66,7 +66,7 @@ func TestGetPodsAndNodes(t *testing.T) {
 		"other/mypod3",
 	}, listPods(podList))
 
-	podList, nodeList = getPodsAndNodes(clientset, "", "moon=lol", "")
+	podList, nodeList = getPodsAndNodes(clientset, "", "moon=lol", "", "")
 	assert.Equal(t, []string{"mynode2"}, listNodes(nodeList))
 	assert.Equal(t, []string{
 		"default/mypod4",
@@ -74,13 +74,19 @@ func TestGetPodsAndNodes(t *testing.T) {
 		"other/mypod3",
 	}, listPods(podList))
 
-	podList, nodeList = getPodsAndNodes(clientset, "a=test", "", "")
+	podList, nodeList = getPodsAndNodes(clientset, "a=test", "", "", "")
 	assert.Equal(t, []string{"mynode", "mynode2"}, listNodes(nodeList))
 	assert.Equal(t, []string{
 		"default/mypod",
 	}, listPods(podList))
 
-	podList, nodeList = getPodsAndNodes(clientset, "a=test,b!=test", "", "app=true")
+	podList, nodeList = getPodsAndNodes(clientset, "a=test,b!=test", "", "app=true", "")
+	assert.Equal(t, []string{"mynode", "mynode2"}, listNodes(nodeList))
+	assert.Equal(t, []string{
+		"default/mypod",
+	}, listPods(podList))
+
+	podList, nodeList = getPodsAndNodes(clientset, "a=test,b!=test", "", "", "default")
 	assert.Equal(t, []string{"mynode", "mynode2"}, listNodes(nodeList))
 	assert.Equal(t, []string{
 		"default/mypod",

--- a/pkg/capacity/printer.go
+++ b/pkg/capacity/printer.go
@@ -38,7 +38,7 @@ func SupportedOutputs() []string {
 	}
 }
 
-func printList(cm *clusterMetric, showContainers, showPods, showUtil bool, output, sortBy string, availableFormat bool) {
+func printList(cm *clusterMetric, showContainers, showPods, showUtil, showNamespace bool, output, sortBy string, availableFormat bool) {
 	if output == JSONOutput || output == YAMLOutput {
 		lp := &listPrinter{
 			cm:             cm,
@@ -54,6 +54,7 @@ func printList(cm *clusterMetric, showContainers, showPods, showUtil bool, outpu
 			showPods:        showPods,
 			showUtil:        showUtil,
 			showContainers:  showContainers,
+			showNamespace:   showNamespace,
 			sortBy:          sortBy,
 			w:               new(tabwriter.Writer),
 			availableFormat: availableFormat,

--- a/pkg/capacity/table.go
+++ b/pkg/capacity/table.go
@@ -26,6 +26,7 @@ type tablePrinter struct {
 	showPods        bool
 	showUtil        bool
 	showContainers  bool
+	showNamespace   bool
 	sortBy          string
 	w               *tabwriter.Writer
 	availableFormat bool
@@ -100,7 +101,9 @@ func (tp *tablePrinter) getLineItems(tl *tableLine) []string {
 	lineItems := []string{tl.node}
 
 	if tp.showContainers || tp.showPods {
-		lineItems = append(lineItems, tl.namespace)
+		if tp.showNamespace {
+			lineItems = append(lineItems, tl.namespace)
+		}
 		lineItems = append(lineItems, tl.pod)
 	}
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -68,7 +68,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&namespaceLabels,
 		"namespace-labels", "", "", "labels to filter namespaces with")
 	rootCmd.PersistentFlags().StringVarP(&namespace,
-		"namespace", "n", "", "only this namespace (default: all)")
+		"namespace", "n", "", "only include pods from this namespace")
 	rootCmd.PersistentFlags().StringVarP(&kubeContext,
 		"context", "", "", "context to use for Kubernetes config")
 	rootCmd.PersistentFlags().StringVarP(&sortBy,

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -28,6 +28,7 @@ var showUtil bool
 var podLabels string
 var nodeLabels string
 var namespaceLabels string
+var namespace string
 var kubeContext string
 var outputFormat string
 var sortBy string
@@ -47,7 +48,7 @@ var rootCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		capacity.FetchAndPrint(showContainers, showPods, showUtil, availableFormat, podLabels, nodeLabels, namespaceLabels, kubeContext, outputFormat, sortBy)
+		capacity.FetchAndPrint(showContainers, showPods, showUtil, availableFormat, podLabels, nodeLabels, namespaceLabels, namespace, kubeContext, outputFormat, sortBy)
 	},
 }
 
@@ -65,7 +66,9 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&nodeLabels,
 		"node-labels", "", "", "labels to filter nodes with")
 	rootCmd.PersistentFlags().StringVarP(&namespaceLabels,
-		"namespace-labels", "n", "", "labels to filter namespaces with")
+		"namespace-labels", "", "", "labels to filter namespaces with")
+	rootCmd.PersistentFlags().StringVarP(&namespace,
+		"namespace", "n", "", "only this namespace (default: all)")
 	rootCmd.PersistentFlags().StringVarP(&kubeContext,
 		"context", "", "", "context to use for Kubernetes config")
 	rootCmd.PersistentFlags().StringVarP(&sortBy,


### PR DESCRIPTION
Fixes: https://github.com/robscott/kube-capacity/issues/38

Also:
- switches `-n` to be an alias to `--namespace`. This is breaking, but aligns with `kubectl`'s convention
- drops `namespace` column when `--namespace` is specified, since it's always the same.

Didn't test it much TBH.