### PR TITLE
allow specifying kubeconfig file to use via cmd line arg

### DIFF
--- a/pkg/capacity/capacity.go
+++ b/pkg/capacity/capacity.go
@@ -29,8 +29,8 @@ import (
 )
 
 // FetchAndPrint gathers cluster resource data and outputs it
-func FetchAndPrint(showContainers, showPods, showUtil, availableFormat bool, podLabels, nodeLabels, namespaceLabels, namespace, kubeContext, output, sortBy string) {
-	clientset, err := kube.NewClientSet(kubeContext)
+func FetchAndPrint(showContainers, showPods, showUtil, availableFormat bool, podLabels, nodeLabels, namespaceLabels, namespace, kubeContext, kubeConfig, output, sortBy string) {
+	clientset, err := kube.NewClientSet(kubeContext, kubeConfig)
 	if err != nil {
 		fmt.Printf("Error connecting to Kubernetes: %v\n", err)
 		os.Exit(1)
@@ -41,7 +41,7 @@ func FetchAndPrint(showContainers, showPods, showUtil, availableFormat bool, pod
 	nmList := &v1beta1.NodeMetricsList{}
 
 	if showUtil {
-		mClientset, err := kube.NewMetricsClientSet(kubeContext)
+		mClientset, err := kube.NewMetricsClientSet(kubeContext, kubeConfig)
 		if err != nil {
 			fmt.Printf("Error connecting to Metrics API: %v\n", err)
 			os.Exit(4)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -30,6 +30,7 @@ var nodeLabels string
 var namespaceLabels string
 var namespace string
 var kubeContext string
+var kubeConfig string
 var outputFormat string
 var sortBy string
 var availableFormat bool
@@ -48,7 +49,7 @@ var rootCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		capacity.FetchAndPrint(showContainers, showPods, showUtil, availableFormat, podLabels, nodeLabels, namespaceLabels, namespace, kubeContext, outputFormat, sortBy)
+		capacity.FetchAndPrint(showContainers, showPods, showUtil, availableFormat, podLabels, nodeLabels, namespaceLabels, namespace, kubeContext, kubeConfig, outputFormat, sortBy)
 	},
 }
 
@@ -71,6 +72,8 @@ func init() {
 		"namespace", "n", "", "only include pods from this namespace")
 	rootCmd.PersistentFlags().StringVarP(&kubeContext,
 		"context", "", "", "context to use for Kubernetes config")
+	rootCmd.PersistentFlags().StringVarP(&kubeConfig,
+		"kubeconfig", "", "", "kubeconfig file to use for Kubernetes config")
 	rootCmd.PersistentFlags().StringVarP(&sortBy,
 		"sort", "", "name",
 		fmt.Sprintf("attribute to sort results be (supports: %v)", capacity.SupportedSortAttributes))

--- a/pkg/kube/clientset.go
+++ b/pkg/kube/clientset.go
@@ -25,8 +25,8 @@ import (
 )
 
 // NewClientSet returns a new Kubernetes clientset
-func NewClientSet(kubeContext string) (*kubernetes.Clientset, error) {
-	config, err := getKubeConfig(kubeContext)
+func NewClientSet(kubeContext, kubeConfig string) (*kubernetes.Clientset, error) {
+	config, err := getKubeConfig(kubeContext, kubeConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -35,8 +35,8 @@ func NewClientSet(kubeContext string) (*kubernetes.Clientset, error) {
 }
 
 // NewMetricsClientSet returns a new clientset for Kubernetes metrics
-func NewMetricsClientSet(kubeContext string) (*metrics.Clientset, error) {
-	config, err := getKubeConfig(kubeContext)
+func NewMetricsClientSet(kubeContext, kubeConfig string) (*metrics.Clientset, error) {
+	config, err := getKubeConfig(kubeContext, kubeConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -44,9 +44,13 @@ func NewMetricsClientSet(kubeContext string) (*metrics.Clientset, error) {
 	return metrics.NewForConfig(config)
 }
 
-func getKubeConfig(kubeContext string) (*rest.Config, error) {
+func getKubeConfig(kubeContext, kubeConfig string) (*rest.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeConfig != "" {
+		loadingRules.ExplicitPath = kubeConfig
+	}
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(),
+		loadingRules,
 		&clientcmd.ConfigOverrides{CurrentContext: kubeContext},
 	).ClientConfig()
 }


### PR DESCRIPTION
Similar to `kubectl --kubeconfig`, allow explicitly specifying the `kubeconfig` file to use (optionally) when running the command.