### PR TITLE
Add support for Darwin/arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,10 @@ builds:
   - linux
   - darwin
   - windows
+  goarch:
+  - arm64
+  - amd64
+  - 386
   goarm:
   - 6
   - 7

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -18,6 +18,15 @@ spec:
     {{addURIAndSha "https://github.com/robscott/kube-capacity/releases/download/{{ .TagName }}/kube-capacity_{{ .TagName }}_Darwin_x86_64.tar.gz" .TagName }}    
   - selector:
       matchLabels:
+        os: darwin
+        arch: arm64
+    bin: kube-capacity
+    files:
+    - from: "*"
+      to: "."
+    {{addURIAndSha "https://github.com/robscott/kube-capacity/releases/download/{{ .TagName }}/kube-capacity_{{ .TagName }}_Darwin_arm64.tar.gz" .TagName }}
+  - selector:
+      matchLabels:
         os: linux
         arch: amd64
     bin: kube-capacity


### PR DESCRIPTION
This PR adds support for `darwin/arm64` on Krew and GitHub releases.