### PR TITLE
Fix GoReleaser / Homebrew configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ changelog:
     - '^docs:'
     - '^test:'
 brews:
-- name: homebrew-tap
+- name: kube-capacity
   tap:
     # The token determines the release type (Github/Gitlab).
     owner: robscott


### PR DESCRIPTION
I previously set an incorrect Homebrew formula filename that caused
kube-capacity to not be released via Homebrew.

This fixes #45  and #43 . Also, based on my local run of `goreleaser` 0.174.1, Mac/ARM builds automatically happen, which fixes #47.