### PR TITLE
Krew: fix DL URLs, add test instructions, add Linux/arm64 and Windows/amd64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
     docker:
       - image: circleci/golang:1.16
         environment:
-          KREW_RELEASE_BOT_VERSION: v0.0.35
+          KREW_RELEASE_BOT_VERSION: v0.0.40
     steps:
       - checkout
       - run: |

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,3 +1,13 @@
+{{- /* To test this krew-release-bot template before committing it:
+  # Replace 0.6.1 below with the current kube-capacity version.
+  # Replace 0.0.40 below with the current version of the krew-release-bot used
+  # in the .circleci/config.yml file.
+  $ docker run -v `pwd`/.krew.yaml:/tmp/template.yaml rajatjindal/krew-release-bot:v0.0.40 krew-release-bot template --tag 0.6.1 --template-file /tmp/template.yaml >dist/krew.yaml
+  # Use krew to install via the krew manifest created above:
+  $ kubectl krew install --manifest=dist/krew.yaml 
+  # Alternatively, test krew downloading different OS and architecture combinations with:
+  $ KREW_OS=windows KREW_ARCH=amd64 kubectl krew install --manifest=dist/krew.yaml
+*/ -}}
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
@@ -15,7 +25,7 @@ spec:
     files:
     - from: "*"
       to: "."
-    {{addURIAndSha "https://github.com/robscott/kube-capacity/releases/download/{{ .TagName }}/kube-capacity_{{ .TagName }}_Darwin_x86_64.tar.gz" .TagName }}    
+    {{addURIAndSha "https://github.com/robscott/kube-capacity/releases/download/v{{ .TagName }}/kube-capacity_{{ .TagName }}_Darwin_x86_64.tar.gz" .TagName }}    
   - selector:
       matchLabels:
         os: darwin
@@ -24,7 +34,7 @@ spec:
     files:
     - from: "*"
       to: "."
-    {{addURIAndSha "https://github.com/robscott/kube-capacity/releases/download/{{ .TagName }}/kube-capacity_{{ .TagName }}_Darwin_arm64.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/robscott/kube-capacity/releases/download/v{{ .TagName }}/kube-capacity_{{ .TagName }}_Darwin_arm64.tar.gz" .TagName }}
   - selector:
       matchLabels:
         os: linux
@@ -33,6 +43,24 @@ spec:
     files:
     - from: "*"
       to: "."
-    {{addURIAndSha "https://github.com/robscott/kube-capacity/releases/download/{{ .TagName }}/kube-capacity_{{ .TagName }}_Linux_x86_64.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/robscott/kube-capacity/releases/download/v{{ .TagName }}/kube-capacity_{{ .TagName }}_Linux_x86_64.tar.gz" .TagName }}
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    bin: kube-capacity
+    files:
+    - from: "*"
+      to: "."
+    {{addURIAndSha "https://github.com/robscott/kube-capacity/releases/download/v{{ .TagName }}/kube-capacity_{{ .TagName }}_Linux_arm64.tar.gz" .TagName }}
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    bin: kube-capacity.exe
+    files:
+    - from: "*"
+      to: "."
+    {{addURIAndSha "https://github.com/robscott/kube-capacity/releases/download/v{{ .TagName }}/kube-capacity_{{ .TagName }}_Windows_x86_64.tar.gz" .TagName }}
   description: |
     A simple CLI that provides an overview of the resource requests, limits, and utilization in a Kubernetes cluster.


### PR DESCRIPTION
* This fixes Krews download URLs, which have been broken since this repository switched
from `x.y.z` to `vx.y.z` git tags, in kube-capacity v0.4.0.
* Linux/arm64 and Windows/amd64 are added to the Crew manifest.
* Instructions are added to the top of `.krew.yaml` describing how to render and test that template.

This addresses issue #54 