### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.17.3-alpine3.14 AS build
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY main.go ./
+COPY pkg/ ./pkg
+RUN go build -o /kube-capacity
+
+FROM alpine:3.14.2
+ENTRYPOINT [ "/kube-capacity" ]
+
+COPY --from=build /kube-capacity /kube-capacity


### PR DESCRIPTION
This PR adds a dockerfile which builds kube-capacity to make it more portable.
It would be great to add an automated build step and push it to a docker registry.