### PR TITLE
incorrect memory value then memory specified in decimal format

### DIFF
--- a/pkg/capacity/resources.go
+++ b/pkg/capacity/resources.go
@@ -370,8 +370,8 @@ func resourceString(resourceType string, actual, allocatable resource.Quantity, 
 			actualStr = fmt.Sprintf("%dMi", formatToMegiBytes(allocatable)-formatToMegiBytes(actual))
 			allocatableStr = fmt.Sprintf("%dMi", formatToMegiBytes(allocatable))
 		default:
-			actualStr = fmt.Sprintf("%d", formatToMegiBytes(allocatable)-formatToMegiBytes(actual))
-			allocatableStr = fmt.Sprintf("%d", formatToMegiBytes(allocatable))
+			actualStr = fmt.Sprintf("%d", allocatable.Value()-actual.Value())
+			allocatableStr = fmt.Sprintf("%d", allocatable.Value())
 		}
 
 		return fmt.Sprintf("%s/%s", actualStr, allocatableStr)
@@ -383,7 +383,7 @@ func resourceString(resourceType string, actual, allocatable resource.Quantity, 
 	case "memory":
 		actualStr = fmt.Sprintf("%dMi", formatToMegiBytes(actual))
 	default:
-		actualStr = fmt.Sprintf("%d", formatToMegiBytes(actual))
+		actualStr = fmt.Sprintf("%d", actual.Value())
 	}
 
 	return fmt.Sprintf("%s (%d%%%%)", actualStr, int64(utilPercent))


### PR DESCRIPTION
bug #66  appears  then  memory request\limit specified in decimal format, so i think if we make format according typeResource everythink will be ok. But there are a few comments
1. Request\Limits will be converted to BinarySi формат
2. formatToMegiBytes function rounds up, not is the best way in all situation. Fore example  128M = 122,0703125 Mi , but function rounds it to 123Mi

before
request memory = 128M
limit memory     = 512M
![image](https://user-images.githubusercontent.com/41143306/179397139-3404ffda-d4a6-424d-bec5-2a74e9cd5463.png)
<img src="https://user-images.githubusercontent.com/41143306/179397193-52a89e3d-b3a0-45a3-a25f-8d7c22b898ce.png" width="60%" height="60%" />)


after
request memory = 128M
limit memory     = 512M
![image](https://user-images.githubusercontent.com/41143306/179397153-35b0da85-98ef-48d3-af97-bc99ad4b0610.png)
<img src="https://user-images.githubusercontent.com/41143306/179397203-12ec537e-cf83-46eb-b3fa-59c49a76b426.png " width="50%" height="50%" />)
