### PR TITLE
Add a flag to exclude tainted nodes

### DIFF
--- a/pkg/capacity/resources.go
+++ b/pkg/capacity/resources.go
@@ -129,6 +129,9 @@ func buildClusterMetric(podList *corev1.PodList, pmList *v1beta1.PodMetricsList,
 
 	if nmList != nil {
 		for _, nm := range nmList.Items {
+			if cm.nodeMetrics[nm.Name] == nil {
+				continue
+			}
 			cm.nodeMetrics[nm.Name].cpu.utilization = nm.Usage["cpu"]
 			cm.nodeMetrics[nm.Name].memory.utilization = nm.Usage["memory"]
 		}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -28,6 +28,7 @@ var showUtil bool
 var showPodCount bool
 var podLabels string
 var nodeLabels string
+var excludeTainted bool
 var namespaceLabels string
 var namespace string
 var kubeContext string
@@ -50,8 +51,8 @@ var rootCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		capacity.FetchAndPrint(showContainers, showPods, showUtil, showPodCount, availableFormat, podLabels, nodeLabels,
-			namespaceLabels, namespace, kubeContext, kubeConfig, outputFormat, sortBy)
+		capacity.FetchAndPrint(showContainers, showPods, showUtil, showPodCount, excludeTainted, availableFormat, podLabels,
+			nodeLabels, namespaceLabels, namespace, kubeContext, kubeConfig, outputFormat, sortBy)
 	},
 }
 
@@ -70,6 +71,8 @@ func init() {
 		"pod-labels", "l", "", "labels to filter pods with")
 	rootCmd.PersistentFlags().StringVarP(&nodeLabels,
 		"node-labels", "", "", "labels to filter nodes with")
+	rootCmd.PersistentFlags().BoolVarP(&excludeTainted,
+		"no-taint", "", false, "exclude nodes with taints")
 	rootCmd.PersistentFlags().StringVarP(&namespaceLabels,
 		"namespace-labels", "", "", "labels to filter namespaces with")
 	rootCmd.PersistentFlags().StringVarP(&namespace,


### PR DESCRIPTION
On a cluster that has many tainted nodes it's not straightforward to understand whether there is sufficient capacity to drain one: nodes with taints can make it seem like there is more capacity than there really would be.

This patch solves for the simplest use case by allowing all tainted nodes to be excluded with a flag.