### PR TITLE
Fix goreleaser error and update README with --no-taint flag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,10 +19,10 @@ archives:
       {{- if (eq . "6") -}}hf
       {{- else -}}v{{- . -}}
       {{- end -}}
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
     {{- end -}}
-  replacements:
-    386: i386
-    amd64: x86_64
   format_overrides:
   - goos: windows
     format: zip

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ kube-capacity --pods --containers --util --output yaml
       --kubeconfig string         kubeconfig file to use for Kubernetes config
   -n, --namespace string          only include pods from this namespace
       --namespace-labels string   labels to filter namespaces with
+      --no-taint                  exclude nodes with taints
       --node-labels string        labels to filter nodes with
   -o, --output string             output format for information
                                     (supports: [table json yaml])


### PR DESCRIPTION
Hello. Very cool project! I am new to open source and would love to get involved. 

Goreleaser published the deprecation of archives.replacements [here](https://goreleaser.com/deprecations/#archivesreplacements)

The solution is to include the replacement in the name_template. 

I was able to get the goreleaser working locally with this change. 

Doc update is related to #91 