### PR TITLE
Add flags for user and group impersonation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ kube-capacity --pods --containers --util --output yaml
 
 ## Flags Supported
 ```
+      --as string                 user to impersonate command with
+      --as-group string           group to impersonate command with
   -c, --containers                includes containers in output
       --context string            context to use for Kubernetes config
   -h, --help                      help for kube-capacity

--- a/pkg/capacity/capacity.go
+++ b/pkg/capacity/capacity.go
@@ -29,8 +29,8 @@ import (
 )
 
 // FetchAndPrint gathers cluster resource data and outputs it
-func FetchAndPrint(showContainers, showPods, showUtil, showPodCount, excludeTainted, availableFormat bool, podLabels, nodeLabels, namespaceLabels, namespace, kubeContext, kubeConfig, output, sortBy string) {
-	clientset, err := kube.NewClientSet(kubeContext, kubeConfig)
+func FetchAndPrint(showContainers, showPods, showUtil, showPodCount, excludeTainted, availableFormat bool, podLabels, nodeLabels, namespaceLabels, namespace, kubeContext, kubeConfig, impersonateUser string, impersonateGroup string, output, sortBy string) {
+	clientset, err := kube.NewClientSet(kubeContext, kubeConfig, impersonateUser, impersonateGroup)
 	if err != nil {
 		fmt.Printf("Error connecting to Kubernetes: %v\n", err)
 		os.Exit(1)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -36,6 +36,8 @@ var kubeConfig string
 var outputFormat string
 var sortBy string
 var availableFormat bool
+var impersonateUser string
+var impersonateGroup string
 
 var rootCmd = &cobra.Command{
 	Use:   "kube-capacity",
@@ -52,7 +54,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		capacity.FetchAndPrint(showContainers, showPods, showUtil, showPodCount, excludeTainted, availableFormat, podLabels,
-			nodeLabels, namespaceLabels, namespace, kubeContext, kubeConfig, outputFormat, sortBy)
+			nodeLabels, namespaceLabels, namespace, kubeContext, kubeConfig, impersonateUser, impersonateGroup, outputFormat, sortBy)
 	},
 }
 
@@ -84,10 +86,13 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&sortBy,
 		"sort", "", "name",
 		fmt.Sprintf("attribute to sort results by (supports: %v)", capacity.SupportedSortAttributes))
-
 	rootCmd.PersistentFlags().StringVarP(&outputFormat,
 		"output", "o", capacity.TableOutput,
 		fmt.Sprintf("output format for information (supports: %v)", capacity.SupportedOutputs()))
+	rootCmd.PersistentFlags().StringVarP(&impersonateUser,
+		"as", "", "", "user to impersonate kube-capacity with")
+	rootCmd.PersistentFlags().StringVarP(&impersonateGroup,
+		"as-group", "", "", "group to impersonate kube-capacity with")
 }
 
 // Execute is the primary entrypoint for this CLI

--- a/pkg/kube/clientset.go
+++ b/pkg/kube/clientset.go
@@ -25,10 +25,20 @@ import (
 )
 
 // NewClientSet returns a new Kubernetes clientset
-func NewClientSet(kubeContext, kubeConfig string) (*kubernetes.Clientset, error) {
+func NewClientSet(kubeContext, kubeConfig string, impersonateUser string, impersonateGroup string) (*kubernetes.Clientset, error) {
 	config, err := getKubeConfig(kubeContext, kubeConfig)
 	if err != nil {
 		return nil, err
+	}
+
+	if impersonateUser != "" || impersonateGroup != "" {
+		config.Impersonate = rest.ImpersonationConfig{}
+		if impersonateUser != "" {
+			config.Impersonate.UserName = impersonateUser
+		}
+		if impersonateGroup != "" {
+			config.Impersonate.Groups = []string{impersonateGroup}
+		}
 	}
 
 	return kubernetes.NewForConfig(config)


### PR DESCRIPTION
As described in issue #30, some companies require administrators to use kubernetes impersonation.
This commit uses familiar flags for impersonation and translates them into the client-go config.

resolves #30 
resolves #104 