### PR TITLE
chore(goreleaser): fix name_template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,14 +14,12 @@ builds:
   - 7
 archives:
 - name_template: |-
-    kube-capacity_{{ .Tag }}_{{ .Os }}_{{ .Arch -}}
+    kube-capacity_{{ .Tag }}_{{ .Os }}_
+    {{- if eq .Arch "amd64" }}x86_64{{ else if eq .Arch "386" }}i386{{ else }}{{ .Arch }}{{ end -}}
     {{- with .Arm -}}
       {{- if (eq . "6") -}}hf
       {{- else -}}v{{- . -}}
       {{- end -}}
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
     {{- end -}}
   format_overrides:
   - goos: windows


### PR DESCRIPTION
name_template was updated by https://github.com/robscott/kube-capacity/pull/108 but the update included a bug.
The bug changed the asset names.

https://github.com/robscott/kube-capacity/releases/tag/v0.8.0-rc1

<img width="601" alt="image" src="https://github.com/robscott/kube-capacity/assets/13323303/7d02e099-56ec-44e6-948b-2e3877c45009">

"amd64" weren't replaced with "x86_64".

## Test

I ran GoReleaser on my laptop and confirmed the issue was solved.

```console
$ goreleaser -v     
  ____       ____      _
 / ___| ___ |  _ \ ___| | ___  __ _ ___  ___ _ __
| |  _ / _ \| |_) / _ \ |/ _ \/ _` / __|/ _ \ '__|
| |_| | (_) |  _ <  __/ |  __/ (_| \__ \  __/ |
 \____|\___/|_| \_\___|_|\___|\__,_|___/\___|_|
goreleaser: Deliver Go Binaries as fast and easily as possible
https://goreleaser.com

GitVersion:    1.24.0
GitCommit:     00c2ff733758f63201811c337f8d043e8fcc9d58
GitTreeState:  false
BuildDate:     2024-02-05T12:18:01Z
BuiltBy:       goreleaser
GoVersion:     go1.21.6
Compiler:      gc
ModuleSum:     h1:jsoS5T2CvPKOyECPATAo8hCvUaX8ok4iAq9m5Zyl1L0=
Platform:      darwin/arm64
```

```console
$ goreleaser release --clean --snapshot                      
  • starting release...
  • loading                                          path=.goreleaser.yml
  • skipping announce, publish and validate...
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=752ea69c9af562d7e692ae180af73b986855838a branch=main current_tag=v0.8.0-rc1 previous_tag=v0.7.4-rc7 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    • DEPRECATED:  brews.tap  should not be used anymore, check https://goreleaser.com/deprecations#brewstap for more info
  • snapshotting
    • building snapshot...                           version=v0.8.0-rc1-next
  • checking distribution directory
    • cleaning dist
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/kube-capacity_windows_386/kube-capacity.exe
    • building                                       binary=dist/kube-capacity_linux_arm64/kube-capacity
    • building                                       binary=dist/kube-capacity_linux_386/kube-capacity
    • building                                       binary=dist/kube-capacity_windows_arm64/kube-capacity.exe
    • building                                       binary=dist/kube-capacity_darwin_arm64/kube-capacity
    • building                                       binary=dist/kube-capacity_darwin_amd64_v1/kube-capacity
    • building                                       binary=dist/kube-capacity_linux_amd64_v1/kube-capacity
    • building                                       binary=dist/kube-capacity_windows_amd64_v1/kube-capacity.exe
    • took: 3s
  • archives
    • creating                                       archive=dist/kube-capacity_v0.8.0-rc1_windows_arm64.zip
    • creating                                       archive=dist/kube-capacity_v0.8.0-rc1_linux_x86_64.tar.gz
    • creating                                       archive=dist/kube-capacity_v0.8.0-rc1_windows_i386.zip
    • creating                                       archive=dist/kube-capacity_v0.8.0-rc1_darwin_arm64.tar.gz
    • creating                                       archive=dist/kube-capacity_v0.8.0-rc1_linux_i386.tar.gz
    • creating                                       archive=dist/kube-capacity_v0.8.0-rc1_darwin_x86_64.tar.gz
    • creating                                       archive=dist/kube-capacity_v0.8.0-rc1_windows_x86_64.zip
    • creating                                       archive=dist/kube-capacity_v0.8.0-rc1_linux_arm64.tar.gz
    • took: 3s
  • calculating checksums
  • homebrew tap formula
    • guessing install                               install=[bin.install "kube-capacity"]
    • guessing install                               install=[bin.install "kube-capacity"]
    • guessing install                               install=[bin.install "kube-capacity"]
    • guessing install                               install=[bin.install "kube-capacity"]
    • writing                                        formula=dist/homebrew/Formula/kube-capacity.rb
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • you are using deprecated options, check the output above for details
  • release succeeded after 6s
  • thanks for using goreleaser!
```

```console
$ ls -1 dist 
artifacts.json
checksums.txt
config.yaml
homebrew
kube-capacity_darwin_amd64_v1
kube-capacity_darwin_arm64
kube-capacity_linux_386
kube-capacity_linux_amd64_v1
kube-capacity_linux_arm64
kube-capacity_v0.8.0-rc1_darwin_arm64.tar.gz
kube-capacity_v0.8.0-rc1_darwin_x86_64.tar.gz
kube-capacity_v0.8.0-rc1_linux_arm64.tar.gz
kube-capacity_v0.8.0-rc1_linux_i386.tar.gz
kube-capacity_v0.8.0-rc1_linux_x86_64.tar.gz
kube-capacity_v0.8.0-rc1_windows_arm64.zip
kube-capacity_v0.8.0-rc1_windows_i386.zip
kube-capacity_v0.8.0-rc1_windows_x86_64.zip
kube-capacity_windows_386
kube-capacity_windows_amd64_v1
kube-capacity_windows_arm64
metadata.json
```