### PR TITLE
chore(goreleaser): fix deprecation warnings

### DIFF
--- a/.github/workflows/goreleaser-build.yaml
+++ b/.github/workflows/goreleaser-build.yaml
@@ -23,4 +23,4 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: build --snapshot --rm-dist
+          args: build --snapshot --clean

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,7 +38,7 @@ changelog:
     - '^test:'
 brews:
 - name: kube-capacity
-  tap:
+  repository:
     # The token determines the release type (Github/Gitlab).
     owner: robscott
     name: homebrew-tap


### PR DESCRIPTION
Fixed deprecation warnings.

https://github.com/robscott/kube-capacity/actions/runs/7882675870/job/21508256820#step:5:30

```
    • DEPRECATED: brews.tap should not be used anymore, check https://goreleaser.com/deprecations#brewstap for more info
```

https://goreleaser.com/deprecations/#brewstap

https://github.com/robscott/kube-capacity/actions/runs/7882675870/job/21508256820#step:5:21

```
  • DEPRECATED: --rm-dist was deprecated in favor of --clean, check https://goreleaser.com/deprecations#-rm-dist for more details
```

https://goreleaser.com/deprecations/#-rm-dist