### PR TITLE
feat: version will be automatically set during the creation of release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,8 @@
 builds:
 - env:
   - CGO_ENABLED=0
+  ldflags:
+      - -X github.com/robscott/kube-capacity/pkg/cmd.version={{.Version}}
   goos:
   - linux
   - darwin
@@ -8,10 +10,10 @@ builds:
   goarch:
   - arm64
   - amd64
-  - 386
+  - "386"
   goarm:
-  - 6
-  - 7
+  - "6"
+  - "7"
 archives:
 - name_template: |-
     kube-capacity_{{ .Tag }}_{{ .Os }}_

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -20,6 +20,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var version string = "development"
+
 func init() {
 	rootCmd.AddCommand(versionCmd)
 }
@@ -28,6 +30,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of kube-capacity",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("kube-capacity version v0.7.4")
+		fmt.Printf("kube-capacity version %s\n", version)
 	},
 }


### PR DESCRIPTION
Hello,

There is the same bug of #27 . I've made a change in the goreleaser file and the version.go file. The version will be automatically set by gorelaser during the creation of the release.

I would like you to accept this PR.

Thanks for the tool.