### PR TITLE
Add sorting via pod count for nodes

### DIFF
--- a/pkg/capacity/resources.go
+++ b/pkg/capacity/resources.go
@@ -38,6 +38,7 @@ var SupportedSortAttributes = [...]string{
 	"mem.util.percentage",
 	"mem.request.percentage",
 	"mem.limit.percentage",
+	"pod.count",
 	"name",
 }
 
@@ -275,6 +276,8 @@ func (cm *clusterMetric) getSortedNodeMetrics(sortBy string) []*nodeMetric {
 			return m2.memory.percent(m2.memory.limit) < m1.memory.percent(m1.memory.limit)
 		case "mem.request.percentage":
 			return m2.memory.percent(m2.memory.request) < m1.memory.percent(m1.memory.request)
+		case "pod.count":
+			return m2.podCount.current < m1.podCount.current
 		default:
 			return m1.name < m2.name
 		}

--- a/pkg/capacity/resources_test.go
+++ b/pkg/capacity/resources_test.go
@@ -184,6 +184,71 @@ func TestBuildClusterMetricFull(t *testing.T) {
 	ensureEqualResourceMetric(t, pm["default-example-pod"].memory, memoryExpected)
 }
 
+func TestSortByPodCount(t *testing.T) {
+	nodeList := &corev1.NodeList{
+		Items: []corev1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-1",
+				},
+				Status: corev1.NodeStatus{
+					Allocatable: corev1.ResourceList{
+						"pods": resource.MustParse("110"),
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-2",
+				},
+				Status: corev1.NodeStatus{
+					Allocatable: corev1.ResourceList{
+						"pods": resource.MustParse("110"),
+					},
+				},
+			},
+		},
+	}
+
+	podList := &corev1.PodList{
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-1",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node-1",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-2",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node-1",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-3",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node-2",
+				},
+			},
+		},
+	}
+
+	cm := buildClusterMetric(podList, nil, nodeList, nil)
+	sortedNodes := cm.getSortedNodeMetrics("pod.count")
+
+	// Node 1 should come first as it has 2 pods vs 1 pod on node 2
+	assert.Equal(t, "node-1", sortedNodes[0].name)
+	assert.Equal(t, "node-2", sortedNodes[1].name)
+	assert.Equal(t, int64(2), sortedNodes[0].podCount.current)
+	assert.Equal(t, int64(1), sortedNodes[1].podCount.current)
+}
+
 func ensureEqualResourceMetric(t *testing.T, actual *resourceMetric, expected *resourceMetric) {
 	assert.Equal(t, actual.allocatable.MilliValue(), expected.allocatable.MilliValue())
 	assert.Equal(t, actual.utilization.MilliValue(), expected.utilization.MilliValue())


### PR DESCRIPTION
Closes #159

# Add Pod Count Sorting Feature

This PR adds the ability to sort nodes by their pod count, addressing the feature request in issue #159.

## Changes
- Added `pod.count` to the list of supported sort attributes
- Implemented sorting logic in [getSortedNodeMetrics](cci:1://file:///Users/ebenamor/kube-capacity/pkg/capacity/resources.go:240:0-286:1) to handle pod count sorting
- Added test coverage for pod count sorting functionality

## Usage
Users can now sort nodes by their pod count using:
```bash
kube-capacity --sort pod.count

NODE          CPU REQUESTS   CPU LIMITS      MEMORY REQUESTS   MEMORY LIMITS   
*             17367m (88%)   29525m (150%)   34312Mi (50%)    45381Mi (66%)  
node-1        3268m (83%)    7861m (200%)    5801Mi (42%)     7539Mi (54%)   
node-2        3227m (82%)    2951m (75%)     3458Mi (25%)     2807Mi (20%)   
node-3        3607m (92%)    7901m (201%)    9544Mi (69%)     15073Mi (109%) 
node-4        3558m (90%)    4111m (104%)    4720Mi (34%)     5019Mi (36%)   
node-5        3707m (94%)    6701m (170%)    10792Mi (78%)    14945Mi (108%) 

kube-capacity --pod-count --sort pod.count

NODE          CPU REQUESTS   CPU LIMITS      MEMORY REQUESTS   MEMORY LIMITS    POD COUNT
*             17367m (88%)   29525m (150%)   34312Mi (50%)    45381Mi (66%)    83/300
node-1        3268m (83%)    7861m (200%)    5801Mi (42%)     7539Mi (54%)     19/60
node-2        3227m (82%)    2951m (75%)     3458Mi (25%)     2807Mi (20%)     17/60
node-3        3607m (92%)    7901m (201%)    9544Mi (69%)     15073Mi (109%)   16/60
node-4        3558m (90%)    4111m (104%)    4720Mi (34%)     5019Mi (36%)     16/60
node-5        3707m (94%)    6701m (170%)    10792Mi (78%)    14945Mi (108%)   15/60