### PR TITLE
fix limit and request availability with -a with json and yaml

### DIFF
--- a/pkg/capacity/list.go
+++ b/pkg/capacity/list.go
@@ -44,12 +44,14 @@ type listContainer struct {
 }
 
 type listResourceOutput struct {
-	Requests       string `json:"requests"`
-	RequestsPct    string `json:"requestsPercent"`
-	Limits         string `json:"limits"`
-	LimitsPct      string `json:"limitsPercent"`
-	Utilization    string `json:"utilization,omitempty"`
-	UtilizationPct string `json:"utilizationPercent,omitempty"`
+	Requests          string `json:"requests"`
+	RequestsPct       string `json:"requestsPercent"`
+	RequestsAvailable string `json:"requestsAvailable,omitempty"`
+	Limits           string `json:"limits"`
+	LimitsPct        string `json:"limitsPercent"`
+	LimitsAvailable  string `json:"limitsAvailable,omitempty"`
+	Utilization      string `json:"utilization,omitempty"`
+	UtilizationPct   string `json:"utilizationPercent,omitempty"`
 }
 
 type listClusterMetrics struct {
@@ -64,12 +66,13 @@ type listClusterTotals struct {
 }
 
 type listPrinter struct {
-	cm             *clusterMetric
-	showPods       bool
-	showContainers bool
-	showUtil       bool
-	showPodCount   bool
-	sortBy         string
+	cm              *clusterMetric
+	showPods        bool
+	showContainers  bool
+	showUtil        bool
+	showPodCount    bool
+	sortBy          string
+	availableFormat bool
 }
 
 func (lp listPrinter) Print(outputType string) {
@@ -154,6 +157,16 @@ func (lp *listPrinter) buildListResourceOutput(item *resourceMetric) *listResour
 		RequestsPct: percentCalculator(item.request),
 		Limits:      valueCalculator(item.limit),
 		LimitsPct:   percentCalculator(item.limit),
+	}
+
+	if lp.availableFormat {
+		available := item.allocatable.DeepCopy()
+		available.Sub(item.request)
+		out.RequestsAvailable = valueCalculator(available)
+
+		available = item.allocatable.DeepCopy()
+		available.Sub(item.limit)
+		out.LimitsAvailable = valueCalculator(available)
 	}
 
 	if lp.showUtil {

--- a/pkg/capacity/printer.go
+++ b/pkg/capacity/printer.go
@@ -47,12 +47,13 @@ func SupportedOutputs() []string {
 func printList(cm *clusterMetric, showContainers, showPods, showUtil, showPodCount, showNamespace bool, output, sortBy string, availableFormat bool) {
 	if output == JSONOutput || output == YAMLOutput {
 		lp := &listPrinter{
-			cm:             cm,
-			showPods:       showPods,
-			showUtil:       showUtil,
-			showContainers: showContainers,
-			showPodCount:   showPodCount,
-			sortBy:         sortBy,
+			cm:              cm,
+			showPods:        showPods,
+			showUtil:        showUtil,
+			showContainers:  showContainers,
+			showPodCount:    showPodCount,
+			sortBy:          sortBy,
+			availableFormat: availableFormat,
 		}
 		lp.Print(output)
 	} else if output == TableOutput {


### PR DESCRIPTION
Closes #92
# Add Available Resources to JSON/YAML Output

## Description
Currently, when using the `-a` flag with JSON/YAML output formats, the available resources are not displayed in a clear format. This PR adds new fields `requestsAvailable` and `limitsAvailable` to show available resources explicitly while maintaining backward compatibility.

## Changes
- Added new fields `requestsAvailable` and `limitsAvailable` to [listResourceOutput](cci:2://file:///Users/ebenamor/kube-capacity/pkg/capacity/list.go:45:0-54:1) struct
- Updated [buildListResourceOutput](cci:1://file:///Users/ebenamor/kube-capacity/pkg/capacity/list.go:150:0-185:1) to calculate and populate available resources
- These fields are only included in the output when using the `-a` flag

## Examples

### Without `-a` flag (unchanged):
```json
{
  "nodes": [
    {
      "name": "minikube",
      "cpu": {
        "requests": "1350m",
        "requestsPercent": "11%",
        "limits": "700m",
        "limitsPercent": "5%"
      },
      "memory": {
        "requests": "522Mi",
        "requestsPercent": "6%",
        "limits": "362Mi",
        "limitsPercent": "4%"
      }
    }
  ]
}
### With `-a` flag (unchanged):
{
  "nodes": [
    {
      "name": "minikube",
      "cpu": {
        "requests": "1350m",
        "requestsPercent": "11%",
        "requestsAvailable": "10650m",
        "limits": "700m",
        "limitsPercent": "5%",
        "limitsAvailable": "11300m"
      },
      "memory": {
        "requests": "522Mi",
        "requestsPercent": "6%",
        "requestsAvailable": "7315Mi",
        "limits": "362Mi",
        "limitsPercent": "4%",
        "limitsAvailable": "7475Mi"
      }
    }
  ]
}