### PR TITLE
Add option --show-labels to list the node labels

### DIFF
--- a/pkg/capacity/capacity.go
+++ b/pkg/capacity/capacity.go
@@ -57,7 +57,7 @@ func FetchAndPrint(opts Options) {
 	cm := buildClusterMetric(podList, pmList, nodeList, nmList)
 	showNamespace := opts.Namespace == ""
 
-	printList(&cm, opts.ShowContainers, opts.ShowPods, opts.ShowUtil, opts.ShowPodCount, showNamespace, opts.HideRequests, opts.HideLimits, opts.OutputFormat, opts.SortBy, opts.AvailableFormat)
+	printList(&cm, opts.ShowContainers, opts.ShowPods, opts.ShowUtil, opts.ShowPodCount, opts.ShowLabels, showNamespace, opts.HideRequests, opts.HideLimits, opts.OutputFormat, opts.SortBy, opts.AvailableFormat)
 }
 
 func getPodsAndNodes(clientset kubernetes.Interface, excludeTainted bool, podLabels, nodeLabels, nodeTaints, namespaceLabels, namespace string) (*corev1.PodList, *corev1.NodeList) {

--- a/pkg/capacity/csv.go
+++ b/pkg/capacity/csv.go
@@ -26,6 +26,7 @@ type csvPrinter struct {
 	showPods       bool
 	showUtil       bool
 	showPodCount   bool
+	showLabels     bool
 	showContainers bool
 	showNamespace  bool
 	sortBy         string
@@ -56,6 +57,7 @@ type csvLine struct {
 	memoryUtilPercentage     string
 	podCountCurrent          string
 	podCountAllocatable      string
+	labels                   string
 }
 
 var csvHeaderStrings = csvLine{
@@ -79,6 +81,7 @@ var csvHeaderStrings = csvLine{
 	memoryUtilPercentage:     "MEMORY UTIL %%",
 	podCountCurrent:          "POD COUNT CURRENT",
 	podCountAllocatable:      "POD COUNT ALLOCATABLE",
+	labels:                   "LABELS",
 }
 
 func (cp *csvPrinter) Print(outputType string) {
@@ -172,6 +175,10 @@ func (cp *csvPrinter) getLineItems(cl *csvLine) []string {
 		lineItems = append(lineItems, cl.podCountAllocatable)
 	}
 
+	if cp.showLabels {
+		lineItems = append(lineItems, cl.labels)
+	}
+
 	return lineItems
 }
 
@@ -197,6 +204,7 @@ func (cp *csvPrinter) printClusterLine() {
 		memoryUtilPercentage:     cp.cm.memory.utilPercentageString(),
 		podCountCurrent:          cp.cm.podCount.podCountCurrentString(),
 		podCountAllocatable:      cp.cm.podCount.podCountAllocatableString(),
+		labels:                   VoidValue,
 	})
 }
 
@@ -222,6 +230,7 @@ func (cp *csvPrinter) printNodeLine(nodeName string, nm *nodeMetric) {
 		memoryUtilPercentage:     nm.memory.utilPercentageString(),
 		podCountCurrent:          nm.podCount.podCountCurrentString(),
 		podCountAllocatable:      nm.podCount.podCountAllocatableString(),
+		labels:                   fmt.Sprintf("%q", nodeLabelsString(nm.labels)), // quote the labels to avoid CSV parsing issues
 	})
 }
 

--- a/pkg/capacity/list.go
+++ b/pkg/capacity/list.go
@@ -23,6 +23,7 @@ import (
 
 type listNodeMetric struct {
 	Name     string              `json:"name"`
+	Labels   map[string]string   `json:"labels,omitempty"`
 	CPU      *listResourceOutput `json:"cpu,omitempty"`
 	Memory   *listResourceOutput `json:"memory,omitempty"`
 	Pods     []*listPod          `json:"pods,omitempty"`
@@ -69,6 +70,7 @@ type listPrinter struct {
 	showContainers bool
 	showUtil       bool
 	showPodCount   bool
+	showLabels     bool
 	sortBy         string
 	hideRequests   bool
 	hideLimits     bool
@@ -119,6 +121,10 @@ func (lp *listPrinter) buildListClusterMetrics() listClusterMetrics {
 
 		if lp.showPodCount {
 			node.PodCount = nodeMetric.podCount.podCountString()
+		}
+
+		if lp.showLabels {
+			node.Labels = nodeMetric.labels
 		}
 
 		if lp.showPods || lp.showContainers {

--- a/pkg/capacity/list_test.go
+++ b/pkg/capacity/list_test.go
@@ -76,6 +76,7 @@ func TestBuildListClusterMetricsAllOptions(t *testing.T) {
 		showPods:       true,
 		showContainers: true,
 		showPodCount:   true,
+		showLabels:     true,
 	}
 
 	lcm := lp.buildListClusterMetrics()
@@ -103,6 +104,7 @@ func TestBuildListClusterMetricsAllOptions(t *testing.T) {
 	assert.EqualValues(t, &listNodeMetric{
 		Name:     "example-node-1",
 		PodCount: "1/110",
+		Labels:   map[string]string{"example.io/os": "example-os-1", "zone": "example-zone-1"},
 		CPU: &listResourceOutput{
 			Requests:       "650m",
 			RequestsPct:    "65%",
@@ -254,6 +256,10 @@ func getTestClusterMetric() clusterMetric {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "example-node-1",
+						Labels: map[string]string{
+							"example.io/os": "example-os-1",
+							"zone":          "example-zone-1",
+						},
 					},
 					Status: corev1.NodeStatus{
 						Allocatable: corev1.ResourceList{
@@ -269,6 +275,10 @@ func getTestClusterMetric() clusterMetric {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "example-node-1",
+						Labels: map[string]string{
+							"example.io/os": "example-os-1",
+							"zone":          "example-zone-1",
+						},
 					},
 					Usage: corev1.ResourceList{
 						"cpu":    resource.MustParse("63m"),

--- a/pkg/capacity/options.go
+++ b/pkg/capacity/options.go
@@ -7,6 +7,7 @@ type Options struct {
 	ShowPods              bool
 	ShowUtil              bool
 	ShowPodCount          bool
+	ShowLabels            bool
 	HideRequests          bool
 	HideLimits            bool
 	PodLabels             string

--- a/pkg/capacity/printer.go
+++ b/pkg/capacity/printer.go
@@ -44,7 +44,7 @@ func SupportedOutputs() []string {
 	}
 }
 
-func printList(cm *clusterMetric, showContainers, showPods, showUtil, showPodCount, showNamespace bool, hideRequests, hideLimits bool, output, sortBy string, availableFormat bool) {
+func printList(cm *clusterMetric, showContainers, showPods, showUtil, showPodCount, showLabels, showNamespace bool, hideRequests, hideLimits bool, output, sortBy string, availableFormat bool) {
 	if output == JSONOutput || output == YAMLOutput {
 		lp := &listPrinter{
 			cm:             cm,
@@ -52,6 +52,7 @@ func printList(cm *clusterMetric, showContainers, showPods, showUtil, showPodCou
 			showUtil:       showUtil,
 			showContainers: showContainers,
 			showPodCount:   showPodCount,
+			showLabels:     showLabels,
 			hideRequests:   hideRequests,
 			hideLimits:     hideLimits,
 			sortBy:         sortBy,
@@ -63,6 +64,7 @@ func printList(cm *clusterMetric, showContainers, showPods, showUtil, showPodCou
 			showPods:        showPods,
 			showUtil:        showUtil,
 			showPodCount:    showPodCount,
+			showLabels:      showLabels,
 			showContainers:  showContainers,
 			showNamespace:   showNamespace,
 			hideRequests:    hideRequests,
@@ -77,6 +79,7 @@ func printList(cm *clusterMetric, showContainers, showPods, showUtil, showPodCou
 			fmt.Println("- Resource limits (enabled by default, disabled with --hide-limits)")
 			fmt.Println("- Resource utilization (enabled with --util)")
 			fmt.Println("- Pod count (enabled with --pod-count)")
+			fmt.Println("- Node labels (enabled with --show-labels)")
 			os.Exit(1)
 		}
 		tp.Print()
@@ -86,6 +89,7 @@ func printList(cm *clusterMetric, showContainers, showPods, showUtil, showPodCou
 			showPods:       showPods,
 			showUtil:       showUtil,
 			showPodCount:   showPodCount,
+			showLabels:     showLabels,
 			showContainers: showContainers,
 			showNamespace:  showNamespace,
 			hideRequests:   hideRequests,

--- a/pkg/capacity/resources.go
+++ b/pkg/capacity/resources.go
@@ -62,6 +62,7 @@ type clusterMetric struct {
 
 type nodeMetric struct {
 	name       string
+	labels     map[string]string
 	cpu        *resourceMetric
 	memory     *resourceMetric
 	podMetrics map[string]*podMetric
@@ -108,7 +109,8 @@ func buildClusterMetric(podList *corev1.PodList, pmList *v1beta1.PodMetricsList,
 		totalPodCurrent += tmpPodCount
 		totalPodAllocatable += node.Status.Allocatable.Pods().Value()
 		cm.nodeMetrics[node.Name] = &nodeMetric{
-			name: node.Name,
+			name:   node.Name,
+			labels: node.Labels,
 			cpu: &resourceMetric{
 				resourceType: "cpu",
 				allocatable:  node.Status.Allocatable["cpu"],
@@ -388,6 +390,19 @@ func (rm *resourceMetric) utilString(availableFormat bool) string {
 // podCountString returns the string representation of podCount struct, example: "15/110"
 func (pc *podCount) podCountString() string {
 	return fmt.Sprintf("%d/%d", pc.current, pc.allocatable)
+}
+
+// nodeLabelsString returns the string representation of node labels map
+func nodeLabelsString(labels map[string]string) string {
+	if labels == nil || len(labels) == 0 {
+		return ""
+	}
+
+	var labelStr string
+	for key, value := range labels {
+		labelStr += fmt.Sprintf("%s=%s,", key, value)
+	}
+	return labelStr[:len(labelStr)-1]
 }
 
 func resourceString(resourceType string, actual, allocatable resource.Quantity, availableFormat bool) string {

--- a/pkg/capacity/resources_test.go
+++ b/pkg/capacity/resources_test.go
@@ -121,6 +121,10 @@ func TestBuildClusterMetricFull(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "example-node-1",
+						Labels: map[string]string{
+							"example.io/os": "example-os-1",
+							"zone":          "example-zone-1",
+						},
 					},
 					Status: corev1.NodeStatus{
 						Allocatable: corev1.ResourceList{
@@ -182,6 +186,12 @@ func TestBuildClusterMetricFull(t *testing.T) {
 	ensureEqualResourceMetric(t, pm["default-example-pod"].cpu, cpuExpected)
 	assert.NotNil(t, pm["default-example-pod"].memory)
 	ensureEqualResourceMetric(t, pm["default-example-pod"].memory, memoryExpected)
+
+	node1LabelsExpected := map[string]string{
+		"example.io/os": "example-os-1",
+		"zone":          "example-zone-1",
+	}
+	assert.Equal(t, cm.nodeMetrics["example-node-1"].labels, node1LabelsExpected)
 }
 
 func TestSortByPodCount(t *testing.T) {

--- a/pkg/capacity/table.go
+++ b/pkg/capacity/table.go
@@ -26,6 +26,7 @@ type tablePrinter struct {
 	showPods        bool
 	showUtil        bool
 	showPodCount    bool
+	showLabels      bool
 	showContainers  bool
 	showNamespace   bool
 	hideRequests    bool
@@ -37,7 +38,7 @@ type tablePrinter struct {
 
 func (tp *tablePrinter) hasVisibleColumns() bool {
 	// Check if any data columns will be shown
-	return !tp.hideRequests || !tp.hideLimits || tp.showUtil || tp.showPodCount
+	return !tp.hideRequests || !tp.hideLimits || tp.showUtil || tp.showPodCount || tp.showLabels
 }
 
 type tableLine struct {
@@ -52,6 +53,7 @@ type tableLine struct {
 	memoryLimits   string
 	memoryUtil     string
 	podCount       string
+	labels         string
 }
 
 var headerStrings = tableLine{
@@ -66,6 +68,7 @@ var headerStrings = tableLine{
 	memoryLimits:   "MEMORY LIMITS",
 	memoryUtil:     "MEMORY UTIL",
 	podCount:       "POD COUNT",
+	labels:         "LABELS",
 }
 
 func (tp *tablePrinter) Print() {
@@ -150,6 +153,10 @@ func (tp *tablePrinter) getLineItems(tl *tableLine) []string {
 		lineItems = append(lineItems, tl.podCount)
 	}
 
+	if tp.showLabels {
+		lineItems = append(lineItems, tl.labels)
+	}
+
 	return lineItems
 }
 
@@ -166,6 +173,7 @@ func (tp *tablePrinter) printClusterLine() {
 		memoryLimits:   tp.cm.memory.limitString(tp.availableFormat),
 		memoryUtil:     tp.cm.memory.utilString(tp.availableFormat),
 		podCount:       tp.cm.podCount.podCountString(),
+		labels:         VoidValue,
 	})
 }
 
@@ -182,6 +190,7 @@ func (tp *tablePrinter) printNodeLine(nodeName string, nm *nodeMetric) {
 		memoryLimits:   nm.memory.limitString(tp.availableFormat),
 		memoryUtil:     nm.memory.utilString(tp.availableFormat),
 		podCount:       nm.podCount.podCountString(),
+		labels:         nodeLabelsString(nm.labels),
 	})
 }
 

--- a/pkg/capacity/table_test.go
+++ b/pkg/capacity/table_test.go
@@ -33,6 +33,7 @@ func TestGetLineItems(t *testing.T) {
 		showPods:       false,
 		showUtil:       false,
 		showPodCount:   false,
+		showLabels:     false,
 		showContainers: true,
 		showNamespace:  true,
 	}
@@ -43,6 +44,7 @@ func TestGetLineItems(t *testing.T) {
 		showContainers: true,
 		showNamespace:  true,
 		showPodCount:   true,
+		showLabels:     true,
 	}
 
 	tl := &tableLine{
@@ -57,6 +59,7 @@ func TestGetLineItems(t *testing.T) {
 		memoryLimits:   "2000Mi",
 		memoryUtil:     "326Mi",
 		podCount:       "1/110",
+		labels:         "zone=example-zone-1",
 	}
 
 	var testCases = []struct {
@@ -106,6 +109,7 @@ func TestGetLineItems(t *testing.T) {
 				"2000Mi",
 				"326Mi",
 				"1/110",
+				"zone=example-zone-1",
 			},
 		},
 	}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -85,6 +85,8 @@ func init() {
 		"hide-requests", "", false, "hide requests from output")
 	rootCmd.PersistentFlags().BoolVarP(&opts.HideLimits,
 		"hide-limits", "", false, "hide limits from output")
+	rootCmd.PersistentFlags().BoolVarP(&opts.ShowLabels,
+		"show-labels", "", false, "includes node labels in output, default hide labels column")
 }
 
 // Execute is the primary entrypoint for this CLI


### PR DESCRIPTION
# Add Node Labels to Output

## Overview  
This PR adds the ability to output the node labels in a similar fashion to `kubectl get nodes --show-labels`. By default, the labels column is hidden.

## Changes  
- Fetch node labels and include them in the cluster metrics.  
- Supporting to all existing output types (json, yaml, table, csv) 

## Sample usage  
```txt
kube-capacity --show-labels

NODE          CPU REQUESTS   CPU LIMITS      MEMORY REQUESTS   MEMORY LIMITS   LABELS
*             17367m (88%)   29525m (150%)   34312Mi (50%)    45381Mi (66%)    
node-1        3268m (83%)    7861m (200%)    5801Mi (42%)     7539Mi (54%)    machine-family=n2d,provisioning=spot,topology.gke.io/zone=asia-south1-c  
node-2        3227m (82%)    2951m (75%)     3458Mi (25%)     2807Mi (20%)    machine-family=n2d,provisioning=ondemand,topology.gke.io/zone=asia-south1-b  
node-3        3607m (92%)    7901m (201%)    9544Mi (69%)     15073Mi (109%)  machine-family=n2d,provisioning=spot,topology.gke.io/zone=asia-south1-c  
node-4        3558m (90%)    4111m (104%)    4720Mi (34%)     5019Mi (36%)    machine-family=n1,provisioning=ondemand,topology.gke.io/zone=asia-south1-a  
node-5        3707m (94%)    6701m (170%)    10792Mi (78%)    14945Mi (108%)  machine-family=n2d,provisioning=spot,topology.gke.io/zone=asia-south1-b  

