### PR TITLE
reduce option plumbing

### DIFF
--- a/pkg/capacity/capacity.go
+++ b/pkg/capacity/capacity.go
@@ -55,9 +55,7 @@ func FetchAndPrint(opts Options) {
 	}
 
 	cm := buildClusterMetric(podList, pmList, nodeList, nmList)
-	showNamespace := opts.Namespace == ""
-
-	printList(&cm, opts.ShowContainers, opts.ShowPods, opts.ShowUtil, opts.ShowPodCount, showNamespace, opts.HideRequests, opts.HideLimits, opts.OutputFormat, opts.SortBy, opts.AvailableFormat)
+	printList(&cm, opts)
 }
 
 func getPodsAndNodes(clientset kubernetes.Interface, excludeTainted bool, podLabels, nodeLabels, nodeTaints, namespaceLabels, namespace string) (*corev1.PodList, *corev1.NodeList) {

--- a/pkg/capacity/list.go
+++ b/pkg/capacity/list.go
@@ -64,14 +64,8 @@ type listClusterTotals struct {
 }
 
 type listPrinter struct {
-	cm             *clusterMetric
-	showPods       bool
-	showContainers bool
-	showUtil       bool
-	showPodCount   bool
-	sortBy         string
-	hideRequests   bool
-	hideLimits     bool
+	cm   *clusterMetric
+	opts Options
 }
 
 func (lp listPrinter) Print(outputType string) {
@@ -107,30 +101,30 @@ func (lp *listPrinter) buildListClusterMetrics() listClusterMetrics {
 		Memory: lp.buildListResourceOutput(lp.cm.memory),
 	}
 
-	if lp.showPodCount {
+	if lp.opts.ShowPodCount {
 		response.ClusterTotals.PodCount = lp.cm.podCount.podCountString()
 	}
 
-	for _, nodeMetric := range lp.cm.getSortedNodeMetrics(lp.sortBy) {
+	for _, nodeMetric := range lp.cm.getSortedNodeMetrics(lp.opts.SortBy) {
 		var node listNodeMetric
 		node.Name = nodeMetric.name
 		node.CPU = lp.buildListResourceOutput(nodeMetric.cpu)
 		node.Memory = lp.buildListResourceOutput(nodeMetric.memory)
 
-		if lp.showPodCount {
+		if lp.opts.ShowPodCount {
 			node.PodCount = nodeMetric.podCount.podCountString()
 		}
 
-		if lp.showPods || lp.showContainers {
-			for _, podMetric := range nodeMetric.getSortedPodMetrics(lp.sortBy) {
+		if lp.opts.ShowPods || lp.opts.ShowContainers {
+			for _, podMetric := range nodeMetric.getSortedPodMetrics(lp.opts.SortBy) {
 				var pod listPod
 				pod.Name = podMetric.name
 				pod.Namespace = podMetric.namespace
 				pod.CPU = lp.buildListResourceOutput(podMetric.cpu)
 				pod.Memory = lp.buildListResourceOutput(podMetric.memory)
 
-				if lp.showContainers {
-					for _, containerMetric := range podMetric.getSortedContainerMetrics(lp.sortBy) {
+				if lp.opts.ShowContainers {
+					for _, containerMetric := range podMetric.getSortedContainerMetrics(lp.opts.SortBy) {
 						pod.Containers = append(pod.Containers, listContainer{
 							Name:   containerMetric.name,
 							Memory: lp.buildListResourceOutput(containerMetric.memory),
@@ -153,17 +147,17 @@ func (lp *listPrinter) buildListResourceOutput(item *resourceMetric) *listResour
 
 	out := listResourceOutput{}
 
-	if !lp.hideRequests {
+	if !lp.opts.HideRequests {
 		out.Requests = valueCalculator(item.request)
 		out.RequestsPct = percentCalculator(item.request)
 	}
 
-	if !lp.hideLimits {
+	if !lp.opts.HideLimits {
 		out.Limits = valueCalculator(item.limit)
 		out.LimitsPct = percentCalculator(item.limit)
 	}
 
-	if lp.showUtil {
+	if lp.opts.ShowUtil {
 		out.Utilization = valueCalculator(item.utilization)
 		out.UtilizationPct = percentCalculator(item.utilization)
 	}

--- a/pkg/capacity/list_test.go
+++ b/pkg/capacity/list_test.go
@@ -71,11 +71,13 @@ func TestBuildListClusterMetricsAllOptions(t *testing.T) {
 	cm := getTestClusterMetric()
 
 	lp := listPrinter{
-		cm:             &cm,
-		showUtil:       true,
-		showPods:       true,
-		showContainers: true,
-		showPodCount:   true,
+		cm: &cm,
+		opts: Options{
+			ShowUtil:       true,
+			ShowPods:       true,
+			ShowContainers: true,
+			ShowPodCount:   true,
+		},
 	}
 
 	lcm := lp.buildListClusterMetrics()

--- a/pkg/capacity/printer.go
+++ b/pkg/capacity/printer.go
@@ -44,57 +44,37 @@ func SupportedOutputs() []string {
 	}
 }
 
-func printList(cm *clusterMetric, showContainers, showPods, showUtil, showPodCount, showNamespace bool, hideRequests, hideLimits bool, output, sortBy string, availableFormat bool) {
+func printList(cm *clusterMetric, opts Options) {
+	output := opts.OutputFormat
 	if output == JSONOutput || output == YAMLOutput {
 		lp := &listPrinter{
-			cm:             cm,
-			showPods:       showPods,
-			showUtil:       showUtil,
-			showContainers: showContainers,
-			showPodCount:   showPodCount,
-			hideRequests:   hideRequests,
-			hideLimits:     hideLimits,
-			sortBy:         sortBy,
+			cm:   cm,
+			opts: opts,
 		}
 		lp.Print(output)
 	} else if output == TableOutput {
 		tp := &tablePrinter{
-			cm:              cm,
-			showPods:        showPods,
-			showUtil:        showUtil,
-			showPodCount:    showPodCount,
-			showContainers:  showContainers,
-			showNamespace:   showNamespace,
-			hideRequests:    hideRequests,
-			hideLimits:      hideLimits,
-			sortBy:          sortBy,
-			w:               new(tabwriter.Writer),
-			availableFormat: availableFormat,
+			cm:   cm,
+			w:    new(tabwriter.Writer),
+			opts: opts,
 		}
 		if !tp.hasVisibleColumns() {
-			fmt.Println("Error: No data columns selected for display. At least one of the following must be enabled:")
-			fmt.Println("- Resource requests (enabled by default, disabled with --hide-requests)")
-			fmt.Println("- Resource limits (enabled by default, disabled with --hide-limits)")
-			fmt.Println("- Resource utilization (enabled with --util)")
-			fmt.Println("- Pod count (enabled with --pod-count)")
+			fmt.Fprintln(os.Stderr, "Error: No data columns selected for display. At least one of the following must be enabled:")
+			fmt.Fprintln(os.Stderr, "- Resource requests (enabled by default, disabled with --hide-requests)")
+			fmt.Fprintln(os.Stderr, "- Resource limits (enabled by default, disabled with --hide-limits)")
+			fmt.Fprintln(os.Stderr, "- Resource utilization (enabled with --util)")
+			fmt.Fprintln(os.Stderr, "- Pod count (enabled with --pod-count)")
 			os.Exit(1)
 		}
 		tp.Print()
 	} else if output == CSVOutput || output == TSVOutput {
 		cp := &csvPrinter{
-			cm:             cm,
-			showPods:       showPods,
-			showUtil:       showUtil,
-			showPodCount:   showPodCount,
-			showContainers: showContainers,
-			showNamespace:  showNamespace,
-			hideRequests:   hideRequests,
-			hideLimits:     hideLimits,
-			sortBy:         sortBy,
+			cm:   cm,
+			opts: opts,
 		}
 		cp.Print(output)
 	} else {
-		fmt.Printf("Called with an unsupported output type: %s", output)
+		fmt.Fprintf(os.Stderr, "Called with an unsupported output type: %s\n", output)
 		os.Exit(1)
 	}
 }

--- a/pkg/capacity/table_test.go
+++ b/pkg/capacity/table_test.go
@@ -22,27 +22,33 @@ import (
 
 func TestGetLineItems(t *testing.T) {
 	tpNone := &tablePrinter{
-		showPods:       false,
-		showUtil:       false,
-		showPodCount:   false,
-		showContainers: false,
-		showNamespace:  false,
+		opts: Options{
+			ShowPods:       false,
+			ShowUtil:       false,
+			ShowPodCount:   false,
+			ShowContainers: false,
+			Namespace:      "example",
+		},
 	}
 
 	tpSome := &tablePrinter{
-		showPods:       false,
-		showUtil:       false,
-		showPodCount:   false,
-		showContainers: true,
-		showNamespace:  true,
+		opts: Options{
+			ShowPods:       false,
+			ShowUtil:       false,
+			ShowPodCount:   false,
+			ShowContainers: true,
+			Namespace:      "",
+		},
 	}
 
 	tpAll := &tablePrinter{
-		showPods:       true,
-		showUtil:       true,
-		showContainers: true,
-		showNamespace:  true,
-		showPodCount:   true,
+		opts: Options{
+			ShowPods:       true,
+			ShowUtil:       true,
+			ShowContainers: true,
+			Namespace:      "",
+			ShowPodCount:   true,
+		},
 	}
 
 	tl := &tableLine{


### PR DESCRIPTION
I was looking at adding a new option and saw that I'd have to pass it around in 6 or so place + add lots of new fields
so trying to simplify that first, so it's just "add to cli, use anywhere you need it"

- makess it easier to "click" on a field and see where/how it is used in the codebase without having to hunt down all the param passing
- avoid method calls with 10+ parameters

cc @robscott 