### PR TITLE
fix: adding patch version to go mod version

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23 # keep in sync with go.mod
+          go-version: 1.23.0 # keep in sync with go.mod
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23 # keep in sync with go.mod
+          go-version: 1.23.0 # keep in sync with go.mod
 
       - name: Build
         run: make build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/robscott/kube-capacity
 
-go 1.23 // keep in sync with .github/workflows/test.yaml and .github/workflows/golangci-lint.yaml
+go 1.23.0 // keep in sync with .github/workflows/test.yaml and .github/workflows/golangci-lint.yaml
 
 require (
 	github.com/spf13/cobra v1.8.1


### PR DESCRIPTION
# Go Versioning 

## Overview  

Go version need to be a full release version specifier. 

With the current Go module version of `1.23`, when I run

``` text
$ go mod tidy
go: downloading go1.23 (linux/amd64)
go: download go1.23 for linux/amd64: toolchain not available
```

Updated Go module Version to `1.23.0`. Cause tootchain version are released with 1.V.0 but not with 1.V. 

`go mod tidy` run successfully.

reference: https://github.com/golang/go/issues/62278#issuecomment-1693538776

## Changes  
- added patch version to Go Version in module file 
- done the same in CI jobs


cc: @grosser (to keep in loop)
