### PR TITLE
fix double % in output

### DIFF
--- a/pkg/capacity/resources.go
+++ b/pkg/capacity/resources.go
@@ -423,7 +423,7 @@ func resourceString(resourceType string, actual, allocatable resource.Quantity, 
 		actualStr = fmt.Sprintf("%d", actual.Value())
 	}
 
-	return fmt.Sprintf("%s (%d%%%%)", actualStr, int64(utilPercent))
+	return fmt.Sprintf("%s (%d%%)", actualStr, int64(utilPercent))
 }
 
 func formatToMegiBytes(actual resource.Quantity) int64 {


### PR DESCRIPTION
```
ip-172-16-114-92.us-west-2.compute.internal    21745m (34%%)     105150m (165%%)    246710Mi (99%%)    293494Mi (118%%)
```

->

```
ip-172-16-114-92.us-west-2.compute.internal    21745m (34%)     105150m (165%)    246710Mi (99%)    293494Mi (118%)
```