### PR TITLE
show age

### DIFF
--- a/pkg/capacity/list.go
+++ b/pkg/capacity/list.go
@@ -18,23 +18,26 @@ import (
 	"encoding/json"
 	"fmt"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
 
 type listNodeMetric struct {
-	Name     string              `json:"name"`
-	CPU      *listResourceOutput `json:"cpu,omitempty"`
-	Memory   *listResourceOutput `json:"memory,omitempty"`
-	Pods     []*listPod          `json:"pods,omitempty"`
-	PodCount string              `json:"podCount,omitempty"`
+	Name              string              `json:"name"`
+	CreationTimeStamp v1.Time             `json:"creationTimeStamp"`
+	CPU               *listResourceOutput `json:"cpu,omitempty"`
+	Memory            *listResourceOutput `json:"memory,omitempty"`
+	Pods              []*listPod          `json:"pods,omitempty"`
+	PodCount          string              `json:"podCount,omitempty"`
 }
 
 type listPod struct {
-	Name       string              `json:"name"`
-	Namespace  string              `json:"namespace"`
-	CPU        *listResourceOutput `json:"cpu"`
-	Memory     *listResourceOutput `json:"memory"`
-	Containers []listContainer     `json:"containers,omitempty"`
+	Name              string              `json:"name"`
+	Namespace         string              `json:"namespace"`
+	CreationTimeStamp v1.Time             `json:"creationTimeStamp"`
+	CPU               *listResourceOutput `json:"cpu"`
+	Memory            *listResourceOutput `json:"memory"`
+	Containers        []listContainer     `json:"containers,omitempty"`
 }
 
 type listContainer struct {
@@ -108,6 +111,7 @@ func (lp *listPrinter) buildListClusterMetrics() listClusterMetrics {
 	for _, nodeMetric := range lp.cm.getSortedNodeMetrics(lp.opts.SortBy) {
 		var node listNodeMetric
 		node.Name = nodeMetric.name
+		node.CreationTimeStamp = nodeMetric.creationTimeStamp
 		node.CPU = lp.buildListResourceOutput(nodeMetric.cpu)
 		node.Memory = lp.buildListResourceOutput(nodeMetric.memory)
 
@@ -120,6 +124,7 @@ func (lp *listPrinter) buildListClusterMetrics() listClusterMetrics {
 				var pod listPod
 				pod.Name = podMetric.name
 				pod.Namespace = podMetric.namespace
+				pod.CreationTimeStamp = podMetric.creationTimeStamp
 				pod.CPU = lp.buildListResourceOutput(podMetric.cpu)
 				pod.Memory = lp.buildListResourceOutput(podMetric.memory)
 


### PR DESCRIPTION
for node/pod
... needs more cleanup and maybe a "hide age" option
but wanted to get your thoughts first before building more @robscott 

all kubectl commands print the `age`, so felt this was missing here,
and when looking a utilization it was always important to ignore new nodes since they still get filled
or be able to see patterns where old nodes are empty etc

```
resource-capacity
NODE                                           CPU REQUESTS      CPU LIMITS         MEMORY REQUESTS    MEMORY LIMITS       AGE
*                                              1118601m (62%%)   8454252m (475%%)   6429870Mi (92%%)   9747512Mi (140%%)
ip-123.internal   62786m (98%%)     656042m (1032%%)   246655Mi (99%%)    491967Mi (197%%)    4d
```