### PR TITLE
cleanup printing logic

### DIFF
--- a/pkg/capacity/csv.go
+++ b/pkg/capacity/csv.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 )
 
+// prints the cluster metrics as csv/tsv lines
 type csvPrinter struct {
 	cm   *clusterMetric
 	file io.Writer
@@ -75,29 +76,28 @@ var csvHeaderStrings = csvLine{
 	labels:                   "LABELS",
 }
 
-func (cp *csvPrinter) Print(outputType string) {
-
+func (cp *csvPrinter) Print() {
 	cp.file = os.Stdout
 
-	sortedNodeMetrics := cp.cm.getSortedNodeMetrics(cp.opts.SortBy)
+	nodeMetrics := cp.cm.getSortedNodeMetrics(cp.opts.SortBy)
 
 	cp.printLine(&csvHeaderStrings)
 
-	if len(sortedNodeMetrics) > 1 {
+	if len(nodeMetrics) > 1 {
 		cp.printClusterLine()
 	}
 
-	for _, nm := range sortedNodeMetrics {
-		cp.printNodeLine(nm.name, nm)
+	for _, nm := range nodeMetrics {
+		cp.printNodeLine(nm)
 
 		if cp.opts.ShowPods || cp.opts.ShowContainers {
 			podMetrics := nm.getSortedPodMetrics(cp.opts.SortBy)
 			for _, pm := range podMetrics {
-				cp.printPodLine(nm.name, pm)
+				cp.printPodLine(nm, pm)
 				if cp.opts.ShowContainers {
 					containerMetrics := pm.getSortedContainerMetrics(cp.opts.SortBy)
 					for _, containerMetric := range containerMetrics {
-						cp.printContainerLine(nm.name, pm, containerMetric)
+						cp.printContainerLine(nm, pm, containerMetric)
 					}
 				}
 			}
@@ -106,9 +106,14 @@ func (cp *csvPrinter) Print(outputType string) {
 }
 
 func (cp *csvPrinter) printLine(cl *csvLine) {
-	separator := ","
-	if cp.opts.OutputFormat == TSVOutput {
+	var separator string
+	switch cp.opts.OutputFormat {
+	case CSVOutput:
+		separator = ","
+	case TSVOutput:
 		separator = "\t"
+	default:
+		panic(fmt.Sprintf("Invalid output format: %s", cp.opts.OutputFormat))
 	}
 
 	lineItems := cp.getLineItems(cl)
@@ -131,10 +136,12 @@ func (cp *csvPrinter) getLineItems(cl *csvLine) []string {
 	}
 
 	lineItems = append(lineItems, cl.cpuCapacity)
+
 	if !cp.opts.HideRequests {
 		lineItems = append(lineItems, cl.cpuRequests)
 		lineItems = append(lineItems, cl.cpuRequestsPercentage)
 	}
+
 	if !cp.opts.HideLimits {
 		lineItems = append(lineItems, cl.cpuLimits)
 		lineItems = append(lineItems, cl.cpuLimitsPercentage)
@@ -146,10 +153,12 @@ func (cp *csvPrinter) getLineItems(cl *csvLine) []string {
 	}
 
 	lineItems = append(lineItems, cl.memoryCapacity)
+
 	if !cp.opts.HideRequests {
 		lineItems = append(lineItems, cl.memoryRequests)
 		lineItems = append(lineItems, cl.memoryRequestsPercentage)
 	}
+
 	if !cp.opts.HideLimits {
 		lineItems = append(lineItems, cl.memoryLimits)
 		lineItems = append(lineItems, cl.memoryLimitsPercentage)
@@ -198,9 +207,9 @@ func (cp *csvPrinter) printClusterLine() {
 	})
 }
 
-func (cp *csvPrinter) printNodeLine(nodeName string, nm *nodeMetric) {
+func (cp *csvPrinter) printNodeLine(nm *nodeMetric) {
 	cp.printLine(&csvLine{
-		node:                     nodeName,
+		node:                     nm.name,
 		namespace:                VoidValue,
 		pod:                      VoidValue,
 		container:                VoidValue,
@@ -224,9 +233,9 @@ func (cp *csvPrinter) printNodeLine(nodeName string, nm *nodeMetric) {
 	})
 }
 
-func (cp *csvPrinter) printPodLine(nodeName string, pm *podMetric) {
+func (cp *csvPrinter) printPodLine(nm *nodeMetric, pm *podMetric) {
 	cp.printLine(&csvLine{
-		node:                     nodeName,
+		node:                     nm.name,
 		namespace:                pm.namespace,
 		pod:                      pm.name,
 		container:                VoidValue,
@@ -247,9 +256,9 @@ func (cp *csvPrinter) printPodLine(nodeName string, pm *podMetric) {
 	})
 }
 
-func (cp *csvPrinter) printContainerLine(nodeName string, pm *podMetric, cm *containerMetric) {
+func (cp *csvPrinter) printContainerLine(nm *nodeMetric, pm *podMetric, cm *containerMetric) {
 	cp.printLine(&csvLine{
-		node:                     nodeName,
+		node:                     nm.name,
 		namespace:                pm.namespace,
 		pod:                      pm.name,
 		container:                cm.name,

--- a/pkg/capacity/list.go
+++ b/pkg/capacity/list.go
@@ -64,12 +64,13 @@ type listClusterTotals struct {
 	PodCount string              `json:"podCount,omitempty"`
 }
 
+// prints the cluster metrics as a list of yaml or json
 type listPrinter struct {
 	cm   *clusterMetric
 	opts Options
 }
 
-func (lp listPrinter) Print(outputType string) {
+func (lp listPrinter) Print() {
 	listOutput := lp.buildListClusterMetrics()
 
 	jsonRaw, err := json.MarshalIndent(listOutput, "", "  ")
@@ -77,9 +78,10 @@ func (lp listPrinter) Print(outputType string) {
 		fmt.Println("Error Marshalling JSON")
 		fmt.Println(err)
 	} else {
-		if outputType == JSONOutput {
+		switch lp.opts.OutputFormat {
+		case JSONOutput:
 			fmt.Printf("%s", jsonRaw)
-		} else {
+		case YAMLOutput:
 			// This is a strange approach, but the k8s YAML package
 			// already marshalls to JSON before converting to YAML,
 			// this just allows us to follow the same code path.
@@ -90,6 +92,8 @@ func (lp listPrinter) Print(outputType string) {
 			} else {
 				fmt.Printf("%s", yamlRaw)
 			}
+		default:
+			fmt.Printf("Error: Unsupported output format %s", lp.opts.OutputFormat)
 		}
 	}
 }

--- a/pkg/capacity/printer.go
+++ b/pkg/capacity/printer.go
@@ -45,14 +45,14 @@ func SupportedOutputs() []string {
 }
 
 func printList(cm *clusterMetric, opts Options) {
-	output := opts.OutputFormat
-	if output == JSONOutput || output == YAMLOutput {
+	switch opts.OutputFormat {
+	case JSONOutput, YAMLOutput:
 		lp := &listPrinter{
 			cm:   cm,
 			opts: opts,
 		}
-		lp.Print(output)
-	} else if output == TableOutput {
+		lp.Print()
+	case TableOutput:
 		tp := &tablePrinter{
 			cm:   cm,
 			w:    new(tabwriter.Writer),
@@ -68,14 +68,14 @@ func printList(cm *clusterMetric, opts Options) {
 			os.Exit(1)
 		}
 		tp.Print()
-	} else if output == CSVOutput || output == TSVOutput {
+	case CSVOutput, TSVOutput:
 		cp := &csvPrinter{
 			cm:   cm,
 			opts: opts,
 		}
-		cp.Print(output)
-	} else {
-		fmt.Fprintf(os.Stderr, "Called with an unsupported output type: %s\n", output)
+		cp.Print()
+	default:
+		fmt.Fprintf(os.Stderr, "Called with an unsupported output type: %s\n", opts.OutputFormat)
 		os.Exit(1)
 	}
 }

--- a/pkg/capacity/table.go
+++ b/pkg/capacity/table.go
@@ -21,6 +21,8 @@ import (
 	"text/tabwriter"
 )
 
+// prints the nodes/pods/containers as a tab separated table just like kubectl does without `-o`
+// produces extra lines when pod and container metrics were requested after each node
 type tablePrinter struct {
 	cm   *clusterMetric
 	w    *tabwriter.Writer
@@ -64,29 +66,31 @@ var headerStrings = tableLine{
 
 func (tp *tablePrinter) Print() {
 	tp.w.Init(os.Stdout, 0, 8, 2, ' ', 0)
-	sortedNodeMetrics := tp.cm.getSortedNodeMetrics(tp.opts.SortBy)
+	nodeMetrics := tp.cm.getSortedNodeMetrics(tp.opts.SortBy)
 
 	tp.printLine(&headerStrings)
 
-	if len(sortedNodeMetrics) > 1 {
+	if len(nodeMetrics) > 1 {
 		tp.printClusterLine()
 	}
 
-	for _, nm := range sortedNodeMetrics {
-		if tp.opts.ShowPods || tp.opts.ShowContainers {
+	showDetails := tp.opts.ShowPods || tp.opts.ShowContainers
+	for _, nm := range nodeMetrics {
+		if showDetails {
 			tp.printLine(&tableLine{})
 		}
 
-		tp.printNodeLine(nm.name, nm)
+		tp.printNodeLine(nm)
 
-		if tp.opts.ShowPods || tp.opts.ShowContainers {
+		if showDetails {
 			podMetrics := nm.getSortedPodMetrics(tp.opts.SortBy)
 			for _, pm := range podMetrics {
-				tp.printPodLine(nm.name, pm)
+				tp.printPodLine(nm, pm)
+
 				if tp.opts.ShowContainers {
 					containerMetrics := pm.getSortedContainerMetrics(tp.opts.SortBy)
-					for _, containerMetric := range containerMetrics {
-						tp.printContainerLine(nm.name, pm, containerMetric)
+					for _, cm := range containerMetrics {
+						tp.printContainerLine(nm, pm, cm)
 					}
 				}
 			}
@@ -99,6 +103,10 @@ func (tp *tablePrinter) Print() {
 	}
 }
 
+// print a line by tab joining all values, adding an extra space so values do not stick to each other
+//
+// TODO: generate all lines first and then right-justify them to the longest value in each column
+// just like kubectl does it
 func (tp *tablePrinter) printLine(tl *tableLine) {
 	lineItems := tp.getLineItems(tl)
 	_, _ = fmt.Fprintln(tp.w, strings.Join(lineItems[:], "\t "))
@@ -108,7 +116,7 @@ func (tp *tablePrinter) getLineItems(tl *tableLine) []string {
 	lineItems := []string{tl.node}
 
 	if tp.opts.ShowContainers || tp.opts.ShowPods {
-		if tp.opts.Namespace == "" {
+		if tp.opts.Namespace == "" { // when showing just 1 namespace we don't need to show it
 			lineItems = append(lineItems, tl.namespace)
 		}
 		lineItems = append(lineItems, tl.pod)
@@ -121,6 +129,7 @@ func (tp *tablePrinter) getLineItems(tl *tableLine) []string {
 	if !tp.opts.HideRequests {
 		lineItems = append(lineItems, tl.cpuRequests)
 	}
+
 	if !tp.opts.HideLimits {
 		lineItems = append(lineItems, tl.cpuLimits)
 	}
@@ -132,6 +141,7 @@ func (tp *tablePrinter) getLineItems(tl *tableLine) []string {
 	if !tp.opts.HideRequests {
 		lineItems = append(lineItems, tl.memoryRequests)
 	}
+
 	if !tp.opts.HideLimits {
 		lineItems = append(lineItems, tl.memoryLimits)
 	}
@@ -168,9 +178,9 @@ func (tp *tablePrinter) printClusterLine() {
 	})
 }
 
-func (tp *tablePrinter) printNodeLine(nodeName string, nm *nodeMetric) {
+func (tp *tablePrinter) printNodeLine(nm *nodeMetric) {
 	tp.printLine(&tableLine{
-		node:           nodeName,
+		node:           nm.name,
 		namespace:      VoidValue,
 		pod:            VoidValue,
 		container:      VoidValue,
@@ -185,9 +195,9 @@ func (tp *tablePrinter) printNodeLine(nodeName string, nm *nodeMetric) {
 	})
 }
 
-func (tp *tablePrinter) printPodLine(nodeName string, pm *podMetric) {
+func (tp *tablePrinter) printPodLine(nm *nodeMetric, pm *podMetric) {
 	tp.printLine(&tableLine{
-		node:           nodeName,
+		node:           nm.name,
 		namespace:      pm.namespace,
 		pod:            pm.name,
 		container:      VoidValue,
@@ -200,9 +210,9 @@ func (tp *tablePrinter) printPodLine(nodeName string, pm *podMetric) {
 	})
 }
 
-func (tp *tablePrinter) printContainerLine(nodeName string, pm *podMetric, cm *containerMetric) {
+func (tp *tablePrinter) printContainerLine(nm *nodeMetric, pm *podMetric, cm *containerMetric) {
 	tp.printLine(&tableLine{
-		node:           nodeName,
+		node:           nm.name,
 		namespace:      pm.namespace,
 		pod:            pm.name,
 		container:      cm.name,


### PR DESCRIPTION
when trying to add [node age](https://github.com/robscott/kube-capacity/pull/188) I noticed that printing extra node columns was hard,
also that the printers could use some docs + consistency
cc @robscott 

