### PR TITLE
feat: add support for custom label columns in output

### DIFF
--- a/pkg/capacity/csv.go
+++ b/pkg/capacity/csv.go
@@ -49,9 +49,10 @@ type csvLine struct {
 	podCountCurrent          string
 	podCountAllocatable      string
 	labels                   string
+	labelColumns             []string
 }
 
-var csvHeaderStrings = csvLine{
+var staticCsvHeaderStrings = csvLine{
 	node:                     "NODE",
 	namespace:                "NAMESPACE",
 	pod:                      "POD",
@@ -73,6 +74,16 @@ var csvHeaderStrings = csvLine{
 	podCountCurrent:          "POD COUNT CURRENT",
 	podCountAllocatable:      "POD COUNT ALLOCATABLE",
 	labels:                   "LABELS",
+	labelColumns:             []string{},
+}
+
+func getCsvHeaderStrings(opts Options) csvLine {
+	h := staticCsvHeaderStrings
+
+	if opts.LabelColumns != "" {
+		h.labelColumns = nodeLabelHeaders(opts.LabelColumns)
+	}
+	return h
 }
 
 func (cp *csvPrinter) Print(outputType string) {
@@ -81,10 +92,14 @@ func (cp *csvPrinter) Print(outputType string) {
 
 	sortedNodeMetrics := cp.cm.getSortedNodeMetrics(cp.opts.SortBy)
 
-	cp.printLine(&csvHeaderStrings)
+	hs := getCsvHeaderStrings(cp.opts)
+	cp.printLine(&hs)
+
+	// number of custom label columns to print
+	labelColumnsCnt := len(hs.labelColumns)
 
 	if len(sortedNodeMetrics) > 1 {
-		cp.printClusterLine()
+		cp.printClusterLine(labelColumnsCnt)
 	}
 
 	for _, nm := range sortedNodeMetrics {
@@ -93,11 +108,11 @@ func (cp *csvPrinter) Print(outputType string) {
 		if cp.opts.ShowPods || cp.opts.ShowContainers {
 			podMetrics := nm.getSortedPodMetrics(cp.opts.SortBy)
 			for _, pm := range podMetrics {
-				cp.printPodLine(nm.name, pm)
+				cp.printPodLine(nm.name, pm, labelColumnsCnt)
 				if cp.opts.ShowContainers {
 					containerMetrics := pm.getSortedContainerMetrics(cp.opts.SortBy)
 					for _, containerMetric := range containerMetrics {
-						cp.printContainerLine(nm.name, pm, containerMetric)
+						cp.printContainerLine(nm.name, pm, containerMetric, labelColumnsCnt)
 					}
 				}
 			}
@@ -169,10 +184,14 @@ func (cp *csvPrinter) getLineItems(cl *csvLine) []string {
 		lineItems = append(lineItems, cl.labels)
 	}
 
+	if cp.opts.LabelColumns != "" {
+		lineItems = append(lineItems, cl.labelColumns...)
+	}
+
 	return lineItems
 }
 
-func (cp *csvPrinter) printClusterLine() {
+func (cp *csvPrinter) printClusterLine(labelColumnsCnt int) {
 	cp.printLine(&csvLine{
 		node:                     VoidValue,
 		namespace:                VoidValue,
@@ -195,6 +214,7 @@ func (cp *csvPrinter) printClusterLine() {
 		podCountCurrent:          cp.cm.podCount.podCountCurrentString(),
 		podCountAllocatable:      cp.cm.podCount.podCountAllocatableString(),
 		labels:                   VoidValue,
+		labelColumns:             make([]string, labelColumnsCnt),
 	})
 }
 
@@ -221,10 +241,11 @@ func (cp *csvPrinter) printNodeLine(nodeName string, nm *nodeMetric) {
 		podCountCurrent:          nm.podCount.podCountCurrentString(),
 		podCountAllocatable:      nm.podCount.podCountAllocatableString(),
 		labels:                   fmt.Sprintf("%q", nodeLabelsString(nm.labels)), // quote the labels to avoid CSV parsing issues
+		labelColumns:             nodeLabelValues(nm.labels, cp.opts.LabelColumns),
 	})
 }
 
-func (cp *csvPrinter) printPodLine(nodeName string, pm *podMetric) {
+func (cp *csvPrinter) printPodLine(nodeName string, pm *podMetric, labelColumnsCnt int) {
 	cp.printLine(&csvLine{
 		node:                     nodeName,
 		namespace:                pm.namespace,
@@ -244,10 +265,11 @@ func (cp *csvPrinter) printPodLine(nodeName string, pm *podMetric) {
 		memoryLimitsPercentage:   pm.memory.limitPercentageString(),
 		memoryUtil:               pm.memory.utilActualString(),
 		memoryUtilPercentage:     pm.memory.utilPercentageString(),
+		labelColumns:             make([]string, labelColumnsCnt),
 	})
 }
 
-func (cp *csvPrinter) printContainerLine(nodeName string, pm *podMetric, cm *containerMetric) {
+func (cp *csvPrinter) printContainerLine(nodeName string, pm *podMetric, cm *containerMetric, labelColumnsCnt int) {
 	cp.printLine(&csvLine{
 		node:                     nodeName,
 		namespace:                pm.namespace,
@@ -267,5 +289,6 @@ func (cp *csvPrinter) printContainerLine(nodeName string, pm *podMetric, cm *con
 		memoryLimitsPercentage:   cm.memory.limitPercentageString(),
 		memoryUtil:               cm.memory.utilActualString(),
 		memoryUtilPercentage:     cm.memory.utilPercentageString(),
+		labelColumns:             make([]string, labelColumnsCnt),
 	})
 }

--- a/pkg/capacity/list.go
+++ b/pkg/capacity/list.go
@@ -116,7 +116,7 @@ func (lp *listPrinter) buildListClusterMetrics() listClusterMetrics {
 			node.PodCount = nodeMetric.podCount.podCountString()
 		}
 
-		if lp.opts.ShowLabels {
+		if lp.opts.ShowLabels || lp.opts.LabelColumns != "" {
 			node.Labels = nodeMetric.labels
 		}
 

--- a/pkg/capacity/options.go
+++ b/pkg/capacity/options.go
@@ -13,6 +13,7 @@ type Options struct {
 	PodLabels             string
 	NodeLabels            string
 	NodeTaints            string
+	LabelColumns          string
 	ExcludeTainted        bool
 	NamespaceLabels       string
 	Namespace             string

--- a/pkg/capacity/resources.go
+++ b/pkg/capacity/resources.go
@@ -17,6 +17,7 @@ package capacity
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -407,6 +408,43 @@ func nodeLabelsString(labels map[string]string) string {
 		labelStr += fmt.Sprintf("%s=%s,", key, value)
 	}
 	return labelStr[:len(labelStr)-1]
+}
+
+func formatNodeLabelHeader(label string) string {
+	parts := strings.Split(label, "/")
+	return strings.ToUpper(parts[len(parts)-1])
+}
+
+// nodeLabelHeaders returns the formatted node label column headers
+func nodeLabelHeaders(optsLabel string) []string {
+	if optsLabel == "" {
+		return []string{}
+	}
+
+	labels := strings.Split(optsLabel, ",")
+
+	for i := range labels {
+		labels[i] = formatNodeLabelHeader(labels[i])
+	}
+	return labels
+}
+
+func nodeLabelValues(labels map[string]string, optsLabel string) []string {
+	if optsLabel == "" {
+		return []string{}
+	}
+
+	columns := strings.Split(optsLabel, ",")
+	values := make([]string, len(columns))
+
+	for i, label := range columns {
+		if val, ok := labels[label]; ok {
+			values[i] = val
+		} else {
+			values[i] = ""
+		}
+	}
+	return values
 }
 
 func resourceString(resourceType string, actual, allocatable resource.Quantity, availableFormat bool) string {

--- a/pkg/capacity/resources_test.go
+++ b/pkg/capacity/resources_test.go
@@ -299,7 +299,7 @@ func TestNodeLabelHeaders(t *testing.T) {
 	assert.Equal(t, []string{}, nodeLabelHeaders(""))
 }
 
-func TestNodeLabelValues(t *testing.T) {	
+func TestNodeLabelValues(t *testing.T) {
 	labels := map[string]string{
 		"example.io/os": "example-os-1",
 		"zone":          "example-zone-1",

--- a/pkg/capacity/resources_test.go
+++ b/pkg/capacity/resources_test.go
@@ -285,3 +285,30 @@ func listPods(p *corev1.PodList) []string {
 
 	return pods
 }
+
+func TestFormatNodeLabelHeader(t *testing.T) {
+	assert.Equal(t, "ZONE", formatNodeLabelHeader("zone"))
+	assert.Equal(t, "OS", formatNodeLabelHeader("example.io/os"))
+	assert.Equal(t, "", formatNodeLabelHeader(""))
+	assert.Equal(t, "", formatNodeLabelHeader("example.io/"))
+}
+
+func TestNodeLabelHeaders(t *testing.T) {
+	assert.Equal(t, []string{"ZONE"}, nodeLabelHeaders("zone"))
+	assert.Equal(t, []string{"ZONE", "ENVIRONMENT"}, nodeLabelHeaders("zone,environment"))
+	assert.Equal(t, []string{}, nodeLabelHeaders(""))
+}
+
+func TestNodeLabelValues(t *testing.T) {	
+	labels := map[string]string{
+		"example.io/os": "example-os-1",
+		"zone":          "example-zone-1",
+	}
+
+	assert.Equal(t, []string{"example-zone-1"}, nodeLabelValues(labels, "zone"))
+	assert.Equal(t, []string{"example-os-1"}, nodeLabelValues(labels, "example.io/os"))
+	assert.Equal(t, []string{"example-zone-1", "example-os-1"}, nodeLabelValues(labels, "zone,example.io/os"))
+	assert.Equal(t, []string{"example-zone-1", ""}, nodeLabelValues(labels, "zone,environment"))
+	assert.Equal(t, []string{""}, nodeLabelValues(labels, "example.io/arch"))
+	assert.Equal(t, []string{}, nodeLabelValues(labels, ""))
+}

--- a/pkg/capacity/table.go
+++ b/pkg/capacity/table.go
@@ -45,9 +45,10 @@ type tableLine struct {
 	memoryUtil     string
 	podCount       string
 	labels         string
+	labelColumns   []string
 }
 
-var headerStrings = tableLine{
+var staticHeaderStrings = tableLine{
 	node:           "NODE",
 	namespace:      "NAMESPACE",
 	pod:            "POD",
@@ -60,16 +61,30 @@ var headerStrings = tableLine{
 	memoryUtil:     "MEMORY UTIL",
 	podCount:       "POD COUNT",
 	labels:         "LABELS",
+	labelColumns:   []string{},
+}
+
+func getHeaderStrings(opts Options) tableLine {
+	h := staticHeaderStrings
+
+	if opts.LabelColumns != "" {
+		h.labelColumns = nodeLabelHeaders(opts.LabelColumns)
+	}
+	return h
 }
 
 func (tp *tablePrinter) Print() {
 	tp.w.Init(os.Stdout, 0, 8, 2, ' ', 0)
 	sortedNodeMetrics := tp.cm.getSortedNodeMetrics(tp.opts.SortBy)
 
-	tp.printLine(&headerStrings)
+	hs := getHeaderStrings(tp.opts)
+	tp.printLine(&hs)
+
+	// number of custom label columns to print
+	labelColumnsCnt := len(hs.labelColumns)
 
 	if len(sortedNodeMetrics) > 1 {
-		tp.printClusterLine()
+		tp.printClusterLine(labelColumnsCnt)
 	}
 
 	for _, nm := range sortedNodeMetrics {
@@ -82,11 +97,11 @@ func (tp *tablePrinter) Print() {
 		if tp.opts.ShowPods || tp.opts.ShowContainers {
 			podMetrics := nm.getSortedPodMetrics(tp.opts.SortBy)
 			for _, pm := range podMetrics {
-				tp.printPodLine(nm.name, pm)
+				tp.printPodLine(nm.name, pm, labelColumnsCnt)
 				if tp.opts.ShowContainers {
 					containerMetrics := pm.getSortedContainerMetrics(tp.opts.SortBy)
 					for _, containerMetric := range containerMetrics {
-						tp.printContainerLine(nm.name, pm, containerMetric)
+						tp.printContainerLine(nm.name, pm, containerMetric, labelColumnsCnt)
 					}
 				}
 			}
@@ -148,10 +163,14 @@ func (tp *tablePrinter) getLineItems(tl *tableLine) []string {
 		lineItems = append(lineItems, tl.labels)
 	}
 
+	if tp.opts.LabelColumns != "" {
+		lineItems = append(lineItems, tl.labelColumns...)
+	}
+
 	return lineItems
 }
 
-func (tp *tablePrinter) printClusterLine() {
+func (tp *tablePrinter) printClusterLine(labelColumnsCnt int) {
 	tp.printLine(&tableLine{
 		node:           VoidValue,
 		namespace:      VoidValue,
@@ -165,6 +184,7 @@ func (tp *tablePrinter) printClusterLine() {
 		memoryUtil:     tp.cm.memory.utilString(tp.opts.AvailableFormat),
 		podCount:       tp.cm.podCount.podCountString(),
 		labels:         VoidValue,
+		labelColumns:   make([]string, labelColumnsCnt),
 	})
 }
 
@@ -182,10 +202,11 @@ func (tp *tablePrinter) printNodeLine(nodeName string, nm *nodeMetric) {
 		memoryUtil:     nm.memory.utilString(tp.opts.AvailableFormat),
 		podCount:       nm.podCount.podCountString(),
 		labels:         nodeLabelsString(nm.labels),
+		labelColumns:   nodeLabelValues(nm.labels, tp.opts.LabelColumns),
 	})
 }
 
-func (tp *tablePrinter) printPodLine(nodeName string, pm *podMetric) {
+func (tp *tablePrinter) printPodLine(nodeName string, pm *podMetric, labelColumnsCnt int) {
 	tp.printLine(&tableLine{
 		node:           nodeName,
 		namespace:      pm.namespace,
@@ -197,10 +218,11 @@ func (tp *tablePrinter) printPodLine(nodeName string, pm *podMetric) {
 		memoryRequests: pm.memory.requestString(tp.opts.AvailableFormat),
 		memoryLimits:   pm.memory.limitString(tp.opts.AvailableFormat),
 		memoryUtil:     pm.memory.utilString(tp.opts.AvailableFormat),
+		labelColumns:   make([]string, labelColumnsCnt),
 	})
 }
 
-func (tp *tablePrinter) printContainerLine(nodeName string, pm *podMetric, cm *containerMetric) {
+func (tp *tablePrinter) printContainerLine(nodeName string, pm *podMetric, cm *containerMetric, labelColumnsCnt int) {
 	tp.printLine(&tableLine{
 		node:           nodeName,
 		namespace:      pm.namespace,
@@ -212,5 +234,6 @@ func (tp *tablePrinter) printContainerLine(nodeName string, pm *podMetric, cm *c
 		memoryRequests: cm.memory.requestString(tp.opts.AvailableFormat),
 		memoryLimits:   cm.memory.limitString(tp.opts.AvailableFormat),
 		memoryUtil:     cm.memory.utilString(tp.opts.AvailableFormat),
+		labelColumns:   make([]string, labelColumnsCnt),
 	})
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -87,6 +87,8 @@ func init() {
 		"hide-limits", "", false, "hide limits from output")
 	rootCmd.PersistentFlags().BoolVarP(&opts.ShowLabels,
 		"show-labels", "", false, "includes node labels in output")
+	rootCmd.PersistentFlags().StringVarP(&opts.LabelColumns,
+		"label-columns", "", "", "comma separated list of node labels to include in output as columns")
 }
 
 // Execute is the primary entrypoint for this CLI


### PR DESCRIPTION
# Custom Label Columns Feature

## Overview

The `--label-columns` feature allows you to display specific node labels as separate columns in the output

Feature link: https://github.com/robscott/kube-capacity/issues/162

Alike to the ```kubectl get nodes --label-columns```

### Sample Usage

```bash
kube-capacity --label-columns kubernetes.io/hostname,kubernetes.io/arch

NODE           CPU REQUESTS   CPU LIMITS   MEMORY REQUESTS   MEMORY LIMITS   HOSTNAME       ARCH
*              750m (4%)      0m (0%)      170Mi (0%)        170Mi (0%)                     
minikube       750m (9%)      0m (0%)      170Mi (1%)        170Mi (1%)      minikube       amd64
minikube-m02   0m (0%)        0m (0%)      0Mi (0%)          0Mi (0%)        minikube-m02   amd64
```

## Changes

- added helper functions for label processing
- changes to support all existing output types (json, yaml, table, csv)
- test file changes


